### PR TITLE
[AIR-1] Add link to docs

### DIFF
--- a/AIR-1/AIR-1.yaml
+++ b/AIR-1/AIR-1.yaml
@@ -2,8 +2,8 @@ blueprint:
   name: Apollo Air Sensor Notifications
   source_url: https://raw.githubusercontent.com/ApolloAutomation/Blueprints/AIR-1/AIR-1.yaml
   author: atwixtor@gmail.com
-  description: 'This blueprint monitors values from Apollo Air sensors and sends a
-    notification if any values exceed the defined thresholds.'
+  description: >
+    [Click here](https://wiki.apolloautomation.com/products/air1/setup/general-tips/) to understand more about each sensor and why we chose the default values for each sensor in the blueprint.
   domain: automation
   input:
     device_id:


### PR DESCRIPTION
Add documentation for users so that they can read about default/safe thresholds and other information.

Alternatively, we could pick each out of the docs and put it inline with each threshold input on the blueprint form...