### PR TITLE
fix encoded url for import

### DIFF
--- a/AIR-1/README.md
+++ b/AIR-1/README.md
@@ -6,4 +6,4 @@ This blueprint monitors values from [Apollo Air](https://apolloautomation.com/pr
 
 Click the badge to import this Blueprint:
 
-[![Open your Home Assistant instance and show the blueprint import dialog with a specific blueprint pre-filled.](https://my.home-assistant.io/badges/blueprint_import.svg)](https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fraw.githubusercontent.com%2FApolloAutomation%2FBlueprints%2AIR-1%2FAIR-1.yaml)
+[![Open your Home Assistant instance and show the blueprint import dialog with a specific blueprint pre-filled.](https://my.home-assistant.io/badges/blueprint_import.svg)](https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fraw.githubusercontent.com%2FApolloAutomation%2FBlueprints%2FAIR-1%2FAIR-1.yaml)


### PR DESCRIPTION
Not sure how that character got dropped. Bad copy pasta replace...a.