### PR TITLE
Fix BTN-1 events triggering after Home Assistant restart

### DIFF
--- a/BTN-1/BTN-1.yaml
+++ b/BTN-1/BTN-1.yaml
@@ -163,13 +163,19 @@ trigger:
   event_data:
     entity_id: '{{ event_4_entity }}'
 action:
-# FIX: This condition prevents triggering on unavailable/unknown states
 - condition: template
   value_template: >
-    {{ trigger.event.data.new_state is not none 
-       and trigger.event.data.new_state.attributes is defined
-       and trigger.event.data.new_state.attributes.event_type is defined
-       and trigger.event.data.new_state.attributes.event_type in ['click', 'double_click', 'triple_click', 'hold'] }}
+    {% set ns = trigger.event.data.new_state %}
+    {% set os = trigger.event.data.old_state %}
+    {{ ns is not none 
+       and os is not none
+       and ns.state not in ['unavailable', 'unknown', '', 'None']
+       and os.state not in ['unavailable', 'unknown', '', 'None']
+       and ns.attributes is defined
+       and 'event_type' in ns.attributes
+       and ns.attributes.event_type is not none
+       and ns.attributes.event_type != ''
+       and ns.attributes.event_type in ['click', 'double_click', 'triple_click', 'hold'] }}
 - variables:
     action: '{{ trigger.event.data.new_state.attributes.event_type }}'
     button: '{{ trigger.id }}'

--- a/BTN-1/BTN-1.yaml
+++ b/BTN-1/BTN-1.yaml
@@ -162,20 +162,10 @@ trigger:
   event_type: state_changed
   event_data:
     entity_id: '{{ event_4_entity }}'
-action:
+conditions:
 - condition: template
-  value_template: >
-    {% set ns = trigger.event.data.new_state %}
-    {% set os = trigger.event.data.old_state %}
-    {{ ns is not none 
-       and os is not none
-       and ns.state not in ['unavailable', 'unknown', '', 'None']
-       and os.state not in ['unavailable', 'unknown', '', 'None']
-       and ns.attributes is defined
-       and 'event_type' in ns.attributes
-       and ns.attributes.event_type is not none
-       and ns.attributes.event_type != ''
-       and ns.attributes.event_type in ['click', 'double_click', 'triple_click', 'hold'] }}
+  value_template: "{{ trigger.event.data.old_state is defined and trigger.event.data.old_state.state != 'unavailable' }}"
+action:
 - variables:
     action: '{{ trigger.event.data.new_state.attributes.event_type }}'
     button: '{{ trigger.id }}'

--- a/BTN-1/BTN-1.yaml
+++ b/BTN-1/BTN-1.yaml
@@ -1,8 +1,9 @@
 blueprint:
   name: Apollo Automation BTN-1 Blueprint
-  description: |-
-    A Blueprint to easily automate with the Apollo Automation [BTN-1 Macro Deck](https://apolloautomation.com/products/btn-1-macro-deck)!
-  author: Brandon Harvey aka Smart Home Sellout. Thanks to [Jesse at ESPHome for the original yaml](https://github.com/jesserockz/blueprints/blob/main/esphome-button-4x.yaml)
+  description: A Blueprint to easily automate with the Apollo Automation [BTN-1 Macro
+    Deck](https://apolloautomation.com/products/btn-1-macro-deck)!
+  author: Brandon Harvey aka Smart Home Sellout. Thanks to [Jesse at ESPHome for the
+    original yaml](https://github.com/jesserockz/blueprints/blob/main/esphome-button-4x.yaml)
   domain: automation
   source_url: https://raw.githubusercontent.com/ApolloAutomation/Blueprints/refs/heads/main/BTN-1/BTN-1.yaml
   input:
@@ -12,9 +13,10 @@ blueprint:
       selector:
         device:
           filter:
-            - integration: esphome
-              manufacturer: ApolloAutomation
-              model: BTN-1
+          - integration: esphome
+            manufacturer: ApolloAutomation
+            model: BTN-1
+          multiple: false
     button_1:
       name: Button 1
       icon: mdi:numeric-1-box-outline
@@ -25,22 +27,22 @@ blueprint:
           name: Single Click
           default: []
           selector:
-            action:
+            action: {}
         button_1_double:
           name: Double Click
           default: []
           selector:
-            action:
+            action: {}
         button_1_triple:
           name: Triple Click
           default: []
           selector:
-            action:
+            action: {}
         button_1_hold:
           name: Hold
           default: []
           selector:
-            action:
+            action: {}
     button_2:
       name: Button 2
       icon: mdi:numeric-2-box-outline
@@ -51,22 +53,22 @@ blueprint:
           name: Single Click
           default: []
           selector:
-            action:
+            action: {}
         button_2_double:
           name: Double Click
           default: []
           selector:
-            action:
+            action: {}
         button_2_triple:
           name: Triple Click
           default: []
           selector:
-            action:
+            action: {}
         button_2_hold:
           name: Hold
           default: []
           selector:
-            action:
+            action: {}
     button_3:
       name: Button 3
       icon: mdi:numeric-3-box-outline
@@ -77,22 +79,22 @@ blueprint:
           name: Single Click
           default: []
           selector:
-            action:
+            action: {}
         button_3_double:
           name: Double Click
           default: []
           selector:
-            action:
+            action: {}
         button_3_triple:
           name: Triple Click
           default: []
           selector:
-            action:
+            action: {}
         button_3_hold:
           name: Hold
           default: []
           selector:
-            action:
+            action: {}
     button_4:
       name: Button 4
       icon: mdi:numeric-4-box-outline
@@ -103,133 +105,144 @@ blueprint:
           name: Single Click
           default: []
           selector:
-            action:
+            action: {}
         button_4_double:
           name: Double Click
           default: []
           selector:
-            action:
+            action: {}
         button_4_triple:
           name: Triple Click
           default: []
           selector:
-            action:
+            action: {}
         button_4_hold:
           name: Hold
           default: []
           selector:
-            action:
-
+            action: {}
 trigger_variables:
   deviceid: !input device
-  entities: "{{ device_entities(deviceid) }}"
+  entities: '{{ device_entities(deviceid) }}'
+  event_1_entity: '{{ entities | selectattr(None, "search", "event.*_button_1") |
+    list | last }}
 
-  event_1_entity: >
-    {{ entities | selectattr(None, "search", "event.*_button_1") | list | last }}
-  event_2_entity: >
-    {{ entities | selectattr(None, "search", "event.*_button_2") | list | last }}
-  event_3_entity: >
-    {{ entities | selectattr(None, "search", "event.*_button_3") | list | last }}
-  event_4_entity: >
-    {{ entities | selectattr(None, "search", "event.*_button_4") | list | last }}
+    '
+  event_2_entity: '{{ entities | selectattr(None, "search", "event.*_button_2") |
+    list | last }}
 
+    '
+  event_3_entity: '{{ entities | selectattr(None, "search", "event.*_button_3") |
+    list | last }}
+
+    '
+  event_4_entity: '{{ entities | selectattr(None, "search", "event.*_button_4") |
+    list | last }}
+
+    '
 mode: parallel
 trigger:
-  - platform: event
-    id: one
-    event_type: state_changed
-    event_data:
-      entity_id: "{{ event_1_entity }}"
-  - platform: event
-    id: two
-    event_type: state_changed
-    event_data:
-      entity_id: "{{ event_2_entity }}"
-  - platform: event
-    id: three
-    event_type: state_changed
-    event_data:
-      entity_id: "{{ event_3_entity }}"
-  - platform: event
-    id: four
-    event_type: state_changed
-    event_data:
-      entity_id: "{{ event_4_entity }}"
-
+- platform: event
+  id: one
+  event_type: state_changed
+  event_data:
+    entity_id: '{{ event_1_entity }}'
+- platform: event
+  id: two
+  event_type: state_changed
+  event_data:
+    entity_id: '{{ event_2_entity }}'
+- platform: event
+  id: three
+  event_type: state_changed
+  event_data:
+    entity_id: '{{ event_3_entity }}'
+- platform: event
+  id: four
+  event_type: state_changed
+  event_data:
+    entity_id: '{{ event_4_entity }}'
 action:
-  - variables:
-      action: "{{ trigger.event.data.new_state.attributes.event_type }}"
-      button: "{{ trigger.id }}"
-  - choose:
+# FIX: This condition prevents triggering on unavailable/unknown states
+- condition: template
+  value_template: >
+    {{ trigger.event.data.new_state is not none 
+       and trigger.event.data.new_state.attributes is defined
+       and trigger.event.data.new_state.attributes.event_type is defined
+       and trigger.event.data.new_state.attributes.event_type in ['click', 'double_click', 'triple_click', 'hold'] }}
+- variables:
+    action: '{{ trigger.event.data.new_state.attributes.event_type }}'
+    button: '{{ trigger.id }}'
+- choose:
+  - conditions:
+    - condition: trigger
+      id:
+      - one
+    sequence:
+    - choose:
       - conditions:
-          - condition: trigger
-            id:
-              - one
-        sequence:
-          - choose:
-              - conditions:
-                  - "{{ action == 'click' }}"
-                sequence: !input "button_1_single"
-              - conditions:
-                  - "{{ action == 'double_click' }}"
-                sequence: !input "button_1_double"
-              - conditions:
-                  - "{{ action == 'triple_click' }}"
-                sequence: !input "button_1_triple"
-              - conditions:
-                  - "{{ action == 'hold' }}"
-                sequence: !input "button_1_hold"
+        - '{{ action == ''click'' }}'
+        sequence: !input button_1_single
       - conditions:
-          - condition: trigger
-            id:
-              - two
-        sequence:
-          - choose:
-              - conditions:
-                  - "{{ action == 'click' }}"
-                sequence: !input "button_2_single"
-              - conditions:
-                  - "{{ action == 'double_click' }}"
-                sequence: !input "button_2_double"
-              - conditions:
-                  - "{{ action == 'triple_click' }}"
-                sequence: !input "button_2_triple"
-              - conditions:
-                  - "{{ action == 'hold' }}"
-                sequence: !input "button_2_hold"
+        - '{{ action == ''double_click'' }}'
+        sequence: !input button_1_double
       - conditions:
-          - condition: trigger
-            id:
-              - three
-        sequence:
-          - choose:
-              - conditions:
-                  - "{{ action == 'click' }}"
-                sequence: !input "button_3_single"
-              - conditions:
-                  - "{{ action == 'double_click' }}"
-                sequence: !input "button_3_double"
-              - conditions:
-                  - "{{ action == 'triple_click' }}"
-                sequence: !input "button_3_triple"
-              - conditions:
-                  - "{{ action == 'hold' }}"
-                sequence: !input "button_3_hold"
+        - '{{ action == ''triple_click'' }}'
+        sequence: !input button_1_triple
       - conditions:
-          - condition: trigger
-            id:
-              - four
-        sequence:
-          - choose:
-              - conditions:
-                  - "{{ action == 'click' }}"
-                sequence: !input "button_4_single"
-              - conditions:
-                  - "{{ action == 'double_click' }}"
-                sequence: !input "button_4_double"
-              - conditions:
-                  - "{{ action == 'triple_click' }}"
-                sequence: !input "button_4_triple"
-              - conditions:
-                  - "{{ action == 'hold' }}"
-                sequence: !input "button_4_hold"
+        - '{{ action == ''hold'' }}'
+        sequence: !input button_1_hold
+  - conditions:
+    - condition: trigger
+      id:
+      - two
+    sequence:
+    - choose:
+      - conditions:
+        - '{{ action == ''click'' }}'
+        sequence: !input button_2_single
+      - conditions:
+        - '{{ action == ''double_click'' }}'
+        sequence: !input button_2_double
+      - conditions:
+        - '{{ action == ''triple_click'' }}'
+        sequence: !input button_2_triple
+      - conditions:
+        - '{{ action == ''hold'' }}'
+        sequence: !input button_2_hold
+  - conditions:
+    - condition: trigger
+      id:
+      - three
+    sequence:
+    - choose:
+      - conditions:
+        - '{{ action == ''click'' }}'
+        sequence: !input button_3_single
+      - conditions:
+        - '{{ action == ''double_click'' }}'
+        sequence: !input button_3_double
+      - conditions:
+        - '{{ action == ''triple_click'' }}'
+        sequence: !input button_3_triple
+      - conditions:
+        - '{{ action == ''hold'' }}'
+        sequence: !input button_3_hold
+  - conditions:
+    - condition: trigger
+      id:
+      - four
+    sequence:
+    - choose:
+      - conditions:
+        - '{{ action == ''click'' }}'
+        sequence: !input button_4_single
+      - conditions:
+        - '{{ action == ''double_click'' }}'
+        sequence: !input button_4_double
+      - conditions:
+        - '{{ action == ''triple_click'' }}'
+        sequence: !input button_4_triple
+      - conditions:
+        - '{{ action == ''hold'' }}'
+        sequence: !input button_4_hold


### PR DESCRIPTION
## Summary
- Fix events triggering incorrectly after Home Assistant restart
- Refine state change conditions for button events
- Fix BTN-1 unavailable/unknown state triggers

## Changes
This PR merges fixes from the beta branch that address issues with the BTN-1 blueprint where events were firing inappropriately after restarting Home Assistant.

### Commits included:
- fix events triggering when they shouldnt
- Refine state change conditions for button events
- fix-btn-1-unavailable-unknown-triggers

## Test plan
- [ ] Test BTN-1 events after Home Assistant restart
- [ ] Verify button events only trigger on actual state changes
- [ ] Confirm no spurious events from unavailable/unknown states

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined blueprint automation configuration with improved event extraction and standardized action handling.
  * Enhanced device selector to restrict matching to a single device.
  * Optimized YAML structure for better readability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->