### PR TITLE
Fix AIR-1 blueprint import URL

### DIFF
--- a/AIR-1/README.md
+++ b/AIR-1/README.md
@@ -6,4 +6,4 @@ This blueprint monitors values from [Apollo Air](https://apolloautomation.com/pr
 
 Click the badge to import this Blueprint:
 
-[![Open your Home Assistant instance and show the blueprint import dialog with a specific blueprint pre-filled.](https://my.home-assistant.io/badges/blueprint_import.svg)](https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fraw.githubusercontent.com%2FApolloAutomation%2FBlueprints%2FAIR-1%2FAIR-1.yaml)
+[![Open your Home Assistant instance and show the blueprint import dialog with a specific blueprint pre-filled.](https://my.home-assistant.io/badges/blueprint_import.svg)](https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fraw.githubusercontent.com%2FApolloAutomation%2FBlueprints%2Fmain%2FAIR-1%2FAIR-1.yaml)


### PR DESCRIPTION
## Summary
- Fixed the blueprint import badge URL in AIR-1/README.md
- The URL was missing the `main` branch, causing 404 errors when importing via Home Assistant

## Problem
The import URL was: `Blueprints/AIR-1/AIR-1.yaml` (treats AIR-1 as a branch)
Should be: `Blueprints/main/AIR-1/AIR-1.yaml` (correct path on main branch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the blueprint import badge URL reference in the README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->