### PR TITLE
feat: Apollo PLT-1 Plant Sensor Alerts blueprint

### DIFF
--- a/PLT-1/PLT-1.yaml
+++ b/PLT-1/PLT-1.yaml
@@ -6,12 +6,23 @@ blueprint:
     🌱 Receive mobile alerts when your Apollo Automation PLT-1 or PLT-1B plant
     sensor detects conditions outside your configured thresholds.
 
-    🪴 Works with both the **PLT-1** (wired) and **PLT-1B** (battery) models.
+    🪴 Works with both the [PLT-1
+    (wired)](https://wiki.apolloautomation.com/products/plt1/calibrating-plt1/)
+    and [PLT-1B
+    (battery)](https://wiki.apolloautomation.com/products/plt1b/calibrating-plt1/)
+    models.
 
-    📖 [Click here](https://wiki.apolloautomation.com) to learn more about the
-    PLT-1 and recommended threshold values for common houseplants.
+    ⚠️ **Calibration required** — your sensor must be calibrated before soil
+    moisture readings are accurate. See the calibration guide for your model:
+    [PLT-1
+    calibration](https://wiki.apolloautomation.com/products/plt1/calibrating-plt1/)
+    | [PLT-1B
+    calibration](https://wiki.apolloautomation.com/products/plt1b/calibrating-plt1/)
 
     **Setup:**
+
+    0️⃣ Calibrate your sensor — enable the Soil ADC entity on your device,
+    record the dry and wet voltage readings, then disable Soil ADC again
 
     1️⃣ Select your PLT-1 or PLT-1B device
 
@@ -19,7 +30,9 @@ blueprint:
 
     3️⃣ Configure your notification device and options
 
-    4️⃣ Enable each sensor group you want to monitor and adjust thresholds
+    4️⃣ Enter your calibration voltages in the Calibration section
+
+    5️⃣ Enable each sensor group you want to monitor and adjust thresholds
   domain: automation
   homeassistant:
     min_version: "2024.6.0"
@@ -182,6 +195,48 @@ blueprint:
                   value: "/15"
                 - label: "Every 30 Minutes"
                   value: "/30"
+
+    # ── Calibration ───────────────────────────────────────────────────────────────
+    calibration_settings:
+      name: Calibration
+      collapsed: true
+      description: >
+        Set the dry and wet calibration voltages for your soil moisture sensor.
+        To get these values: temporarily enable the Soil ADC diagnostic entity
+        on your device (Settings → Devices & Services → your PLT-1 → enable
+        Soil ADC), record the raw voltage with the probe dry in air, then
+        again with the probe submerged in water up to the Apollo label only.
+        Disable Soil ADC again when done — especially important on the PLT-1B
+        to preserve battery life.
+      icon: mdi:tune-variant
+      input:
+        dry_voltage_value:
+          name: Dry Voltage (V)
+          description: >
+            ADC voltage reading with probe dry in air. Default is 1.7 V —
+            update this after reading your Soil ADC entity.
+          default: 1.7
+          selector:
+            number:
+              min: 0.0
+              max: 3.3
+              step: 0.01
+              unit_of_measurement: V
+              mode: box
+
+        wet_voltage_value:
+          name: Wet Voltage (V)
+          description: >
+            ADC voltage reading with probe submerged in water up to the Apollo
+            label. Do not submerge further. Default is 0.9 V.
+          default: 0.9
+          selector:
+            number:
+              min: 0.0
+              max: 3.3
+              step: 0.01
+              unit_of_measurement: V
+              mode: box
 
     # ── Soil Moisture (collapsed) ─────────────────────────────────────────────────
     soil_moisture_settings:
@@ -553,6 +608,13 @@ trigger_variables:
   time_hours: !input time_hours
   disable_repeat: !input disable_repeat
 
+  dry_voltage_entity: >-
+    {{ device_entities(device_id) | select('match', 'number\..*dry_voltage.*') | list | first | default('') }}
+  wet_voltage_entity: >-
+    {{ device_entities(device_id) | select('match', 'number\..*wet_voltage.*|number\..*100_water.*') | list | first | default('') }}
+  dry_voltage_value: !input dry_voltage_value
+  wet_voltage_value: !input wet_voltage_value
+
 # ── Triggers ─────────────────────────────────────────────────────────────────────
 triggers:
   # Repeat / reminder schedule
@@ -681,6 +743,26 @@ conditions:
     value_template: "{{ not disable_repeat or trigger.id != 'time' }}"
 
 action:
+  # Apply calibration voltages to device
+  - if:
+      - condition: template
+        value_template: "{{ dry_voltage_entity != '' }}"
+    then:
+      - action: number.set_value
+        target:
+          entity_id: "{{ dry_voltage_entity }}"
+        data:
+          value: "{{ dry_voltage_value }}"
+  - if:
+      - condition: template
+        value_template: "{{ wet_voltage_entity != '' }}"
+    then:
+      - action: number.set_value
+        target:
+          entity_id: "{{ wet_voltage_entity }}"
+        data:
+          value: "{{ wet_voltage_value }}"
+
   # Soil Moisture — Low
   - alias: Soil Moisture Low Alert
     if:

--- a/PLT-1/PLT-1.yaml
+++ b/PLT-1/PLT-1.yaml
@@ -222,9 +222,9 @@ blueprint:
         dry_voltage_value:
           name: Dry Voltage (V)
           description: >
-            ADC voltage reading with probe dry in air. Default is 1.7 V —
+            ADC voltage reading with probe dry in air. Default is 2.77 V —
             update this after reading your Soil ADC entity.
-          default: 1.7
+          default: 2.77
           selector:
             number:
               min: 0.0
@@ -237,8 +237,8 @@ blueprint:
           name: Wet Voltage (V)
           description: >
             ADC voltage reading with probe submerged in water up to the Apollo
-            label. Do not submerge further. Default is 0.9 V.
-          default: 0.9
+            label. Do not submerge further. Default is 1.47 V.
+          default: 1.47
           selector:
             number:
               min: 0.0

--- a/PLT-1/PLT-1.yaml
+++ b/PLT-1/PLT-1.yaml
@@ -793,7 +793,8 @@ action:
               Soil moisture is {{ states(soil_moisture_entity) | float(0) | round(1) }}%,
               below the minimum of {{ min_soil_moisture }}%. Time to water!
             data: "{{ device_message_data }}"
-      - !input custom_action
+      - choose: []
+        default: !input custom_action
 
   # Soil Moisture — High
   - alias: Soil Moisture High Alert
@@ -817,7 +818,8 @@ action:
               Soil moisture is {{ states(soil_moisture_entity) | float(0) | round(1) }}%,
               above the maximum of {{ max_soil_moisture }}%. Risk of overwatering!
             data: "{{ device_message_data }}"
-      - !input custom_action
+      - choose: []
+        default: !input custom_action
 
   # Soil Temperature — Low
   - alias: Soil Temperature Low Alert
@@ -842,7 +844,8 @@ action:
               below the minimum of {{ min_soil_temp }}{{ state_attr(soil_temp_entity, 'unit_of_measurement') }}.
               Roots may be too cold!
             data: "{{ device_message_data }}"
-      - !input custom_action
+      - choose: []
+        default: !input custom_action
 
   # Soil Temperature — High
   - alias: Soil Temperature High Alert
@@ -867,7 +870,8 @@ action:
               above the maximum of {{ max_soil_temp }}{{ state_attr(soil_temp_entity, 'unit_of_measurement') }}.
               Roots may overheat!
             data: "{{ device_message_data }}"
-      - !input custom_action
+      - choose: []
+        default: !input custom_action
 
   # Air Temperature — Low
   - alias: Air Temperature Low Alert
@@ -892,7 +896,8 @@ action:
               below the minimum of {{ min_air_temp }}{{ state_attr(air_temp_entity, 'unit_of_measurement') }}.
               Environment may be too cold!
             data: "{{ device_message_data }}"
-      - !input custom_action
+      - choose: []
+        default: !input custom_action
 
   # Air Temperature — High
   - alias: Air Temperature High Alert
@@ -917,7 +922,8 @@ action:
               above the maximum of {{ max_air_temp }}{{ state_attr(air_temp_entity, 'unit_of_measurement') }}.
               Environment may be too hot!
             data: "{{ device_message_data }}"
-      - !input custom_action
+      - choose: []
+        default: !input custom_action
 
   # Air Humidity — Low
   - alias: Air Humidity Low Alert
@@ -942,7 +948,8 @@ action:
               below the minimum of {{ min_air_humidity }}%.
               Dry air can stress your plant!
             data: "{{ device_message_data }}"
-      - !input custom_action
+      - choose: []
+        default: !input custom_action
 
   # Air Humidity — High
   - alias: Air Humidity High Alert
@@ -967,7 +974,8 @@ action:
               above the maximum of {{ max_air_humidity }}%.
               Risk of mold or rot!
             data: "{{ device_message_data }}"
-      - !input custom_action
+      - choose: []
+        default: !input custom_action
 
   # Light — Too Dark
   - alias: Light Too Low Alert
@@ -992,7 +1000,8 @@ action:
               below the minimum of {{ min_light }} lux.
               Move to a brighter spot!
             data: "{{ device_message_data }}"
-      - !input custom_action
+      - choose: []
+        default: !input custom_action
 
   # Light — Too Bright
   - alias: Light Too High Alert
@@ -1017,7 +1026,8 @@ action:
               above the maximum of {{ max_light }} lux.
               Direct sun may scorch leaves!
             data: "{{ device_message_data }}"
-      - !input custom_action
+      - choose: []
+        default: !input custom_action
 
   # UV Index — High
   - alias: UV Index High Alert
@@ -1042,7 +1052,8 @@ action:
               above the maximum of {{ max_uv }}.
               Excessive UV exposure!
             data: "{{ device_message_data }}"
-      - !input custom_action
+      - choose: []
+        default: !input custom_action
 
   # Battery — Low (PLT-1B only)
   - alias: Battery Low Alert
@@ -1067,7 +1078,8 @@ action:
               below the minimum of {{ min_battery }}%.
               Please recharge!
             data: "{{ device_message_data }}"
-      - !input custom_action
+      - choose: []
+        default: !input custom_action
 
 mode: parallel
 max: 10

--- a/PLT-1/PLT-1.yaml
+++ b/PLT-1/PLT-1.yaml
@@ -282,19 +282,6 @@ blueprint:
               step: 1
               mode: slider
 
-        soil_moisture_for:
-          name: Soil Moisture Alert Delay (minutes)
-          description: >
-            How long the moisture must be outside the threshold before an alert fires.
-            Prevents false alerts from brief sensor fluctuations.
-          default: 5
-          selector:
-            number:
-              min: 0
-              max: 60
-              unit_of_measurement: "min"
-              step: 1
-
     # ── Soil Temperature (collapsed) ──────────────────────────────────────────────
     soil_temp_settings:
       name: Soil Temperature
@@ -329,16 +316,6 @@ blueprint:
               unit_of_measurement: "°C"
               step: 0.5
 
-        soil_temp_for:
-          name: Soil Temperature Alert Delay (minutes)
-          default: 10
-          selector:
-            number:
-              min: 0
-              max: 120
-              unit_of_measurement: "min"
-              step: 1
-
     # ── Air Temperature (collapsed) ────────────────────────────────────────────────
     air_temp_settings:
       name: Air Temperature
@@ -372,16 +349,6 @@ blueprint:
               max: 50
               unit_of_measurement: "°C"
               step: 0.5
-
-        air_temp_for:
-          name: Air Temperature Alert Delay (minutes)
-          default: 10
-          selector:
-            number:
-              min: 0
-              max: 120
-              unit_of_measurement: "min"
-              step: 1
 
     # ── Air Humidity (collapsed) ───────────────────────────────────────────────────
     air_humidity_settings:
@@ -419,16 +386,6 @@ blueprint:
               step: 1
               mode: slider
 
-        air_humidity_for:
-          name: Air Humidity Alert Delay (minutes)
-          default: 10
-          selector:
-            number:
-              min: 0
-              max: 120
-              unit_of_measurement: "min"
-              step: 1
-
     # ── Light Intensity (collapsed) ────────────────────────────────────────────────
     light_settings:
       name: Light Intensity
@@ -463,16 +420,6 @@ blueprint:
               unit_of_measurement: "lux"
               step: 100
 
-        light_for:
-          name: Light Alert Delay (minutes)
-          default: 30
-          selector:
-            number:
-              min: 0
-              max: 120
-              unit_of_measurement: "min"
-              step: 1
-
     # ── UV Index (collapsed) ──────────────────────────────────────────────────────
     uv_settings:
       name: UV Index
@@ -494,16 +441,6 @@ blueprint:
               min: 0
               max: 11
               unit_of_measurement: "UV index"
-              step: 1
-
-        uv_for:
-          name: UV Alert Delay (minutes)
-          default: 15
-          selector:
-            number:
-              min: 0
-              max: 60
-              unit_of_measurement: "min"
               step: 1
 
     # ── Battery (PLT-1B only, collapsed) ──────────────────────────────────────────
@@ -531,15 +468,6 @@ blueprint:
               step: 5
               mode: slider
 
-        battery_for:
-          name: Battery Alert Delay (minutes)
-          default: 1
-          selector:
-            number:
-              min: 0
-              max: 60
-              unit_of_measurement: "min"
-              step: 1
 
 # ── Trigger Variables ────────────────────────────────────────────────────────────
 trigger_variables:
@@ -637,8 +565,6 @@ triggers:
       {{ soil_moisture_enabled and soil_moisture_entity != ''
          and is_number(states(soil_moisture_entity))
          and states(soil_moisture_entity) | float < min_soil_moisture }}
-    for:
-      minutes: !input soil_moisture_for
     id: soil_moisture_min
 
   - trigger: template
@@ -646,8 +572,6 @@ triggers:
       {{ soil_moisture_enabled and soil_moisture_entity != ''
          and is_number(states(soil_moisture_entity))
          and states(soil_moisture_entity) | float > max_soil_moisture }}
-    for:
-      minutes: !input soil_moisture_for
     id: soil_moisture_max
 
   # Soil temperature
@@ -656,8 +580,6 @@ triggers:
       {{ soil_temp_enabled and soil_temp_entity != ''
          and is_number(states(soil_temp_entity))
          and states(soil_temp_entity) | float < min_soil_temp }}
-    for:
-      minutes: !input soil_temp_for
     id: soil_temp_min
 
   - trigger: template
@@ -665,8 +587,6 @@ triggers:
       {{ soil_temp_enabled and soil_temp_entity != ''
          and is_number(states(soil_temp_entity))
          and states(soil_temp_entity) | float > max_soil_temp }}
-    for:
-      minutes: !input soil_temp_for
     id: soil_temp_max
 
   # Air temperature
@@ -675,8 +595,6 @@ triggers:
       {{ air_temp_enabled and air_temp_entity != ''
          and is_number(states(air_temp_entity))
          and states(air_temp_entity) | float < min_air_temp }}
-    for:
-      minutes: !input air_temp_for
     id: air_temp_min
 
   - trigger: template
@@ -684,8 +602,6 @@ triggers:
       {{ air_temp_enabled and air_temp_entity != ''
          and is_number(states(air_temp_entity))
          and states(air_temp_entity) | float > max_air_temp }}
-    for:
-      minutes: !input air_temp_for
     id: air_temp_max
 
   # Air humidity
@@ -694,8 +610,6 @@ triggers:
       {{ air_humidity_enabled and air_humidity_entity != ''
          and is_number(states(air_humidity_entity))
          and states(air_humidity_entity) | float < min_air_humidity }}
-    for:
-      minutes: !input air_humidity_for
     id: air_humidity_min
 
   - trigger: template
@@ -703,8 +617,6 @@ triggers:
       {{ air_humidity_enabled and air_humidity_entity != ''
          and is_number(states(air_humidity_entity))
          and states(air_humidity_entity) | float > max_air_humidity }}
-    for:
-      minutes: !input air_humidity_for
     id: air_humidity_max
 
   # Light intensity
@@ -713,8 +625,6 @@ triggers:
       {{ light_enabled and light_entity != ''
          and is_number(states(light_entity))
          and states(light_entity) | float < min_light }}
-    for:
-      minutes: !input light_for
     id: light_min
 
   - trigger: template
@@ -722,8 +632,6 @@ triggers:
       {{ light_enabled and light_entity != ''
          and is_number(states(light_entity))
          and states(light_entity) | float > max_light }}
-    for:
-      minutes: !input light_for
     id: light_max
 
   # UV index
@@ -732,8 +640,6 @@ triggers:
       {{ uv_enabled and uv_entity != ''
          and is_number(states(uv_entity))
          and states(uv_entity) | float > max_uv }}
-    for:
-      minutes: !input uv_for
     id: uv_max
 
   # Battery (PLT-1B only)
@@ -742,8 +648,6 @@ triggers:
       {{ battery_enabled and battery_entity != ''
          and is_number(states(battery_entity))
          and states(battery_entity) | float < min_battery }}
-    for:
-      minutes: !input battery_for
     id: battery_min
 
 conditions:

--- a/PLT-1/PLT-1.yaml
+++ b/PLT-1/PLT-1.yaml
@@ -47,7 +47,19 @@ blueprint:
               model: PLT-1
             - integration: esphome
               manufacturer: ApolloAutomation
+              model: PLT-1_Minimal
+            - integration: esphome
+              manufacturer: ApolloAutomation
+              model: PLT-1BLE
+            - integration: esphome
+              manufacturer: ApolloAutomation
               model: PLT-1B
+            - integration: esphome
+              manufacturer: ApolloAutomation
+              model: PLT-1B_Minimal
+            - integration: esphome
+              manufacturer: ApolloAutomation
+              model: PLT-1BBLE
           multiple: false
 
     plant_name:

--- a/PLT-1/PLT-1.yaml
+++ b/PLT-1/PLT-1.yaml
@@ -3,21 +3,18 @@ blueprint:
   source_url: https://github.com/ApolloAutomation/Blueprints/blob/main/PLT-1/PLT-1.yaml
   author: Brandon Harvey aka Smart Home Sellout
   description: >
-    🌱 Receive mobile alerts when your Apollo Automation PLT-1 or PLT-1B plant
-    sensor detects conditions outside your configured thresholds.
+    🌱 Receive mobile alerts when your Apollo Automation PLT-1 detects low soil
+    moisture and more!
 
     🪴 Works with both the [PLT-1
-    (wired)](https://wiki.apolloautomation.com/products/plt1/calibrating-plt1/)
-    and [PLT-1B
-    (battery)](https://wiki.apolloautomation.com/products/plt1b/calibrating-plt1/)
+    (wired)](https://wiki.apolloautomation.com/products/plt1/introduction/) and
+    [PLT-1B
+    (battery)](https://wiki.apolloautomation.com/products/plt1b/introduction/)
     models.
 
     ⚠️ **Calibration required** — your sensor must be calibrated before soil
-    moisture readings are accurate. See the calibration guide for your model:
-    [PLT-1
-    calibration](https://wiki.apolloautomation.com/products/plt1/calibrating-plt1/)
-    | [PLT-1B
-    calibration](https://wiki.apolloautomation.com/products/plt1b/calibrating-plt1/)
+    moisture readings are accurate. See the [calibration
+    guide](https://wiki.apolloautomation.com/products/general/calibrating-and-updating/calibrate-plt1).
 
     **Setup:**
 

--- a/PLT-1/PLT-1.yaml
+++ b/PLT-1/PLT-1.yaml
@@ -1,7 +1,7 @@
 blueprint:
   name: Apollo Automation PLT-1 Blueprint
   source_url: https://github.com/ApolloAutomation/Blueprints/blob/main/PLT-1/PLT-1.yaml
-  author: ApolloAutomation
+  author: Brandon Harvey aka Smart Home Sellout
   description: >
     🌱 Receive mobile alerts when your Apollo Automation PLT-1 or PLT-1B plant
     sensor detects conditions outside your configured thresholds.

--- a/PLT-1/PLT-1.yaml
+++ b/PLT-1/PLT-1.yaml
@@ -1,0 +1,948 @@
+blueprint:
+  name: Apollo PLT-1 Plant Sensor Alerts
+  source_url: https://github.com/ApolloAutomation/Blueprints/blob/main/PLT-1/PLT-1.yaml
+  author: ApolloAutomation
+  description: >
+    Receive alerts when your Apollo Automation PLT-1 or PLT-1B plant sensor
+    detects soil moisture, temperature, humidity, light, UV, or battery levels
+    outside your configured thresholds.
+
+    Works with both the **PLT-1** (wired) and **PLT-1B** (battery) models.
+
+    [Click here](https://wiki.apolloautomation.com) to learn more about the PLT-1
+    and recommended threshold values for common houseplants.
+
+    **Setup:**
+    1. Select your PLT-1 or PLT-1B device
+    2. Enter your plant's name
+    3. Configure your notification device and options
+    4. Enable each sensor group you want to monitor and adjust thresholds
+  domain: automation
+  homeassistant:
+    min_version: "2024.6.0"
+  input:
+
+    # ── Device ─────────────────────────────────────────────────────────────────
+    device_id:
+      name: PLT-1 Device
+      description: Select your Apollo Automation PLT-1 or PLT-1B plant sensor.
+      selector:
+        device:
+          filter:
+            - integration: esphome
+              manufacturer: ApolloAutomation
+              model: PLT-1
+            - integration: esphome
+              manufacturer: ApolloAutomation
+              model: PLT-1B
+          multiple: false
+
+    plant_name:
+      name: Plant Name
+      description: Name of your plant. Used to personalise alert messages.
+      default: "My Plant"
+      selector:
+        text:
+
+    # ── Notification Device ─────────────────────────────────────────────────────
+    notify_device:
+      name: Notify Device
+      description: >
+        Select the mobile device to send push notifications to (requires the
+        Home Assistant Companion App). Leave blank to use only the Custom Action
+        below.
+      default: ""
+      selector:
+        device:
+          integration: mobile_app
+          multiple: false
+
+    # ── Notification Options (collapsed) ────────────────────────────────────────
+    notify_options:
+      name: Notification Options
+      icon: mdi:bell-cog
+      collapsed: true
+      input:
+        notify_interruption_level:
+          name: Interruption Level — iOS Only
+          description: >
+            On iOS 15+ you can set how urgently notifications interrupt you.
+            Critical and Time-Sensitive notifications require them to be enabled
+            in the Home Assistant App.
+            [More info](https://community.home-assistant.io/t/653754/192?u=blacky)
+          default: active
+          selector:
+            select:
+              mode: dropdown
+              options:
+                - label: Default
+                  value: "active"
+                - label: Critical Notifications
+                  value: "critical"
+                - label: Time Sensitive Notifications
+                  value: "time-sensitive"
+                - label: Quiet — No Screen Wake
+                  value: "passive"
+
+        notify_data:
+          name: Android Options (Optional)
+          description: >
+            **High Priority** bypasses delivery delays for instant alerts.
+            **Sticky Notification** keeps the alert visible until manually dismissed.
+            **Notification Channel** lets you customise sound and vibration per channel.
+          default: []
+          selector:
+            select:
+              multiple: true
+              options:
+                - label: High Priority
+                  value: "high_priority"
+                - label: Sticky Notification
+                  value: "sticky"
+                - label: Notification Channel
+                  value: "channel"
+
+        notify_channel:
+          name: Android Notification Channel (Optional)
+          description: Channel name when "Notification Channel" is selected above.
+          default: ""
+          selector:
+            text:
+
+    # ── Custom Action (collapsed) ────────────────────────────────────────────────
+    custom_action_settings:
+      name: Custom Action
+      icon: mdi:lightning-bolt
+      collapsed: true
+      input:
+        custom_action:
+          name: Custom Action (Optional)
+          description: >
+            Run any additional action whenever an alert fires — TTS announcement,
+            light flash, email, or any other notification service.
+          default: []
+          selector:
+            action:
+
+    # ── Repeat / Timing (collapsed) ──────────────────────────────────────────────
+    time_settings:
+      name: Repeat Alerts
+      collapsed: true
+      description: >
+        Set a repeating schedule to re-send reminders while a condition persists.
+        Alerts also fire immediately when a threshold is first crossed.
+      icon: mdi:clock-alert
+      input:
+        time_hours:
+          name: Repeat — Hours
+          description: How often (by hour) to re-send alerts when conditions persist.
+          default: "*"
+          selector:
+            select:
+              mode: dropdown
+              options:
+                - label: "Every Hour"
+                  value: "*"
+                - label: "Every 2 Hours"
+                  value: "/2"
+                - label: "Every 4 Hours"
+                  value: "/4"
+                - label: "Every 6 Hours"
+                  value: "/6"
+                - label: "Every 12 Hours"
+                  value: "/12"
+                - label: "Never (disable repeat)"
+                  value: "none"
+
+        time_minutes:
+          name: Repeat — Minutes
+          description: Minute offset for the repeat schedule.
+          default: "1"
+          selector:
+            select:
+              mode: dropdown
+              options:
+                - label: "At :01"
+                  value: "1"
+                - label: "Every 5 Minutes"
+                  value: "/5"
+                - label: "Every 10 Minutes"
+                  value: "/10"
+                - label: "Every 15 Minutes"
+                  value: "/15"
+                - label: "Every 30 Minutes"
+                  value: "/30"
+
+    # ── Soil Moisture (collapsed) ─────────────────────────────────────────────────
+    soil_moisture_settings:
+      name: Soil Moisture
+      icon: mdi:water-percent
+      collapsed: true
+      input:
+        soil_moisture_enabled:
+          name: Enable Soil Moisture Alerts
+          default: true
+          selector:
+            boolean:
+
+        min_soil_moisture:
+          name: Minimum Soil Moisture (%)
+          description: Alert when moisture drops below this level — plant may need watering.
+          default: 20
+          selector:
+            number:
+              min: 0
+              max: 100
+              unit_of_measurement: "%"
+              step: 1
+              mode: slider
+
+        max_soil_moisture:
+          name: Maximum Soil Moisture (%)
+          description: Alert when moisture rises above this level — risk of overwatering.
+          default: 80
+          selector:
+            number:
+              min: 0
+              max: 100
+              unit_of_measurement: "%"
+              step: 1
+              mode: slider
+
+        soil_moisture_for:
+          name: Soil Moisture Alert Delay (minutes)
+          description: >
+            How long the moisture must be outside the threshold before an alert fires.
+            Prevents false alerts from brief sensor fluctuations.
+          default: 5
+          selector:
+            number:
+              min: 0
+              max: 60
+              unit_of_measurement: "min"
+              step: 1
+
+    # ── Soil Temperature (collapsed) ──────────────────────────────────────────────
+    soil_temp_settings:
+      name: Soil Temperature
+      icon: mdi:thermometer
+      collapsed: true
+      input:
+        soil_temp_enabled:
+          name: Enable Soil Temperature Alerts
+          default: false
+          selector:
+            boolean:
+
+        min_soil_temp:
+          name: Minimum Soil Temperature (°C)
+          description: Alert when soil temperature drops below this value — roots may be too cold.
+          default: 10
+          selector:
+            number:
+              min: -10
+              max: 50
+              unit_of_measurement: "°C"
+              step: 0.5
+
+        max_soil_temp:
+          name: Maximum Soil Temperature (°C)
+          description: Alert when soil temperature rises above this value — roots may overheat.
+          default: 30
+          selector:
+            number:
+              min: -10
+              max: 50
+              unit_of_measurement: "°C"
+              step: 0.5
+
+        soil_temp_for:
+          name: Soil Temperature Alert Delay (minutes)
+          default: 10
+          selector:
+            number:
+              min: 0
+              max: 120
+              unit_of_measurement: "min"
+              step: 1
+
+    # ── Air Temperature (collapsed) ────────────────────────────────────────────────
+    air_temp_settings:
+      name: Air Temperature
+      icon: mdi:home-thermometer
+      collapsed: true
+      input:
+        air_temp_enabled:
+          name: Enable Air Temperature Alerts
+          default: false
+          selector:
+            boolean:
+
+        min_air_temp:
+          name: Minimum Air Temperature (°C)
+          description: Alert when ambient temperature drops below this value.
+          default: 15
+          selector:
+            number:
+              min: -10
+              max: 50
+              unit_of_measurement: "°C"
+              step: 0.5
+
+        max_air_temp:
+          name: Maximum Air Temperature (°C)
+          description: Alert when ambient temperature rises above this value.
+          default: 32
+          selector:
+            number:
+              min: -10
+              max: 50
+              unit_of_measurement: "°C"
+              step: 0.5
+
+        air_temp_for:
+          name: Air Temperature Alert Delay (minutes)
+          default: 10
+          selector:
+            number:
+              min: 0
+              max: 120
+              unit_of_measurement: "min"
+              step: 1
+
+    # ── Air Humidity (collapsed) ───────────────────────────────────────────────────
+    air_humidity_settings:
+      name: Air Humidity
+      icon: mdi:water-percent
+      collapsed: true
+      input:
+        air_humidity_enabled:
+          name: Enable Air Humidity Alerts
+          default: false
+          selector:
+            boolean:
+
+        min_air_humidity:
+          name: Minimum Air Humidity (%)
+          description: Alert when humidity drops below this level — dry air stresses plants.
+          default: 30
+          selector:
+            number:
+              min: 0
+              max: 100
+              unit_of_measurement: "%"
+              step: 1
+              mode: slider
+
+        max_air_humidity:
+          name: Maximum Air Humidity (%)
+          description: Alert when humidity rises above this level — risk of mold or rot.
+          default: 80
+          selector:
+            number:
+              min: 0
+              max: 100
+              unit_of_measurement: "%"
+              step: 1
+              mode: slider
+
+        air_humidity_for:
+          name: Air Humidity Alert Delay (minutes)
+          default: 10
+          selector:
+            number:
+              min: 0
+              max: 120
+              unit_of_measurement: "min"
+              step: 1
+
+    # ── Light Intensity (collapsed) ────────────────────────────────────────────────
+    light_settings:
+      name: Light Intensity
+      icon: mdi:weather-sunny
+      collapsed: true
+      input:
+        light_enabled:
+          name: Enable Light Intensity Alerts
+          default: false
+          selector:
+            boolean:
+
+        min_light:
+          name: Minimum Light (lux)
+          description: Alert when light drops below this level — too dark for healthy growth.
+          default: 100
+          selector:
+            number:
+              min: 0
+              max: 100000
+              unit_of_measurement: "lux"
+              step: 10
+
+        max_light:
+          name: Maximum Light (lux)
+          description: Alert when light rises above this level — too bright or direct sun.
+          default: 50000
+          selector:
+            number:
+              min: 0
+              max: 200000
+              unit_of_measurement: "lux"
+              step: 100
+
+        light_for:
+          name: Light Alert Delay (minutes)
+          default: 30
+          selector:
+            number:
+              min: 0
+              max: 120
+              unit_of_measurement: "min"
+              step: 1
+
+    # ── UV Index (collapsed) ──────────────────────────────────────────────────────
+    uv_settings:
+      name: UV Index
+      icon: mdi:sun-wireless
+      collapsed: true
+      input:
+        uv_enabled:
+          name: Enable UV Index Alerts
+          default: false
+          selector:
+            boolean:
+
+        max_uv:
+          name: Maximum UV Index
+          description: Alert when UV index rises above this level — excessive UV exposure.
+          default: 6
+          selector:
+            number:
+              min: 0
+              max: 11
+              unit_of_measurement: "UV index"
+              step: 1
+
+        uv_for:
+          name: UV Alert Delay (minutes)
+          default: 15
+          selector:
+            number:
+              min: 0
+              max: 60
+              unit_of_measurement: "min"
+              step: 1
+
+    # ── Battery (PLT-1B only, collapsed) ──────────────────────────────────────────
+    battery_settings:
+      name: Battery (PLT-1B only)
+      icon: mdi:battery-alert
+      collapsed: true
+      input:
+        battery_enabled:
+          name: Enable Battery Alerts (PLT-1B only)
+          description: Only applies to battery-powered PLT-1B models — has no effect on wired PLT-1 devices.
+          default: false
+          selector:
+            boolean:
+
+        min_battery:
+          name: Minimum Battery Level (%)
+          description: Alert when battery drops below this percentage.
+          default: 20
+          selector:
+            number:
+              min: 5
+              max: 50
+              unit_of_measurement: "%"
+              step: 5
+              mode: slider
+
+        battery_for:
+          name: Battery Alert Delay (minutes)
+          default: 1
+          selector:
+            number:
+              min: 0
+              max: 60
+              unit_of_measurement: "min"
+              step: 1
+
+# ── Trigger Variables ────────────────────────────────────────────────────────────
+trigger_variables:
+
+  # Device and entity discovery
+  device_id: !input device_id
+  plant_name: !input plant_name
+  entities: >-
+    {{ device_entities(device_id) | select('search', '^sensor\.') | list }}
+
+  soil_moisture_entity: >-
+    {{ entities | select('search', 'soil_moisture') | reject('search', 'adc') | list | first | default('') }}
+  soil_temp_entity: >-
+    {{ entities | select('search', 'soil_temperature') | list | first | default('') }}
+  air_temp_entity: >-
+    {{ entities | select('search', 'aht_temperature') | list | first | default('') }}
+  air_humidity_entity: >-
+    {{ entities | select('search', 'aht_humidity') | list | first | default('') }}
+  light_entity: >-
+    {{ entities | select('search', 'ltr390light') | list | first | default('') }}
+  uv_entity: >-
+    {{ entities | select('search', 'ltr390uvindex') | list | first | default('') }}
+  battery_entity: >-
+    {{ entities | select('search', 'batt_pct') | list | first | default('') }}
+
+  # Enable flags
+  soil_moisture_enabled: !input soil_moisture_enabled
+  soil_temp_enabled: !input soil_temp_enabled
+  air_temp_enabled: !input air_temp_enabled
+  air_humidity_enabled: !input air_humidity_enabled
+  light_enabled: !input light_enabled
+  uv_enabled: !input uv_enabled
+  battery_enabled: !input battery_enabled
+
+  # Thresholds
+  min_soil_moisture: !input min_soil_moisture
+  max_soil_moisture: !input max_soil_moisture
+  min_soil_temp: !input min_soil_temp
+  max_soil_temp: !input max_soil_temp
+  min_air_temp: !input min_air_temp
+  max_air_temp: !input max_air_temp
+  min_air_humidity: !input min_air_humidity
+  max_air_humidity: !input max_air_humidity
+  min_light: !input min_light
+  max_light: !input max_light
+  max_uv: !input max_uv
+  min_battery: !input min_battery
+
+  # Notification
+  notify_device: !input notify_device
+  notify_interruption_level: !input notify_interruption_level
+  notify_data: !input notify_data
+  notify_channel: !input notify_channel
+  device_message_data: >-
+    {% set message = namespace(data={}) %}
+    {% set push = namespace(data={}) %}
+    {% if notify_interruption_level in ['active', 'critical', 'time-sensitive', 'passive'] %}
+      {% set push.data = dict(push.data, **{ 'interruption-level': notify_interruption_level }) %}
+    {% endif %}
+    {% if push.data %}
+      {% set message.data = dict(message.data, **{ 'push': push.data }) %}
+    {% endif %}
+    {% if 'high_priority' in notify_data %}
+      {% set message.data = dict(message.data, **{ 'ttl': 0, 'priority': 'high' }) %}
+    {% endif %}
+    {% if 'sticky' in notify_data %}
+      {% set message.data = dict(message.data, **{ 'sticky': "true" }) %}
+    {% endif %}
+    {% if 'channel' in notify_data and notify_channel != '' %}
+      {% set message.data = dict(message.data, **{ 'channel': notify_channel }) %}
+    {% endif %}
+    {{ message.data }}
+
+  time_hours: !input time_hours
+
+# ── Triggers ─────────────────────────────────────────────────────────────────────
+triggers:
+  # Repeat / reminder schedule
+  - trigger: time_pattern
+    hours: !input time_hours
+    minutes: !input time_minutes
+    id: time
+
+  # Soil moisture
+  - trigger: template
+    value_template: >-
+      {{ soil_moisture_enabled and soil_moisture_entity != ''
+         and states(soil_moisture_entity) | float(50) < min_soil_moisture }}
+    for:
+      minutes: !input soil_moisture_for
+    id: soil_moisture_min
+
+  - trigger: template
+    value_template: >-
+      {{ soil_moisture_enabled and soil_moisture_entity != ''
+         and states(soil_moisture_entity) | float(50) > max_soil_moisture }}
+    for:
+      minutes: !input soil_moisture_for
+    id: soil_moisture_max
+
+  # Soil temperature
+  - trigger: template
+    value_template: >-
+      {{ soil_temp_enabled and soil_temp_entity != ''
+         and states(soil_temp_entity) | float(20) < min_soil_temp }}
+    for:
+      minutes: !input soil_temp_for
+    id: soil_temp_min
+
+  - trigger: template
+    value_template: >-
+      {{ soil_temp_enabled and soil_temp_entity != ''
+         and states(soil_temp_entity) | float(20) > max_soil_temp }}
+    for:
+      minutes: !input soil_temp_for
+    id: soil_temp_max
+
+  # Air temperature
+  - trigger: template
+    value_template: >-
+      {{ air_temp_enabled and air_temp_entity != ''
+         and states(air_temp_entity) | float(20) < min_air_temp }}
+    for:
+      minutes: !input air_temp_for
+    id: air_temp_min
+
+  - trigger: template
+    value_template: >-
+      {{ air_temp_enabled and air_temp_entity != ''
+         and states(air_temp_entity) | float(20) > max_air_temp }}
+    for:
+      minutes: !input air_temp_for
+    id: air_temp_max
+
+  # Air humidity
+  - trigger: template
+    value_template: >-
+      {{ air_humidity_enabled and air_humidity_entity != ''
+         and states(air_humidity_entity) | float(50) < min_air_humidity }}
+    for:
+      minutes: !input air_humidity_for
+    id: air_humidity_min
+
+  - trigger: template
+    value_template: >-
+      {{ air_humidity_enabled and air_humidity_entity != ''
+         and states(air_humidity_entity) | float(50) > max_air_humidity }}
+    for:
+      minutes: !input air_humidity_for
+    id: air_humidity_max
+
+  # Light intensity
+  - trigger: template
+    value_template: >-
+      {{ light_enabled and light_entity != ''
+         and states(light_entity) | float(1000) < min_light }}
+    for:
+      minutes: !input light_for
+    id: light_min
+
+  - trigger: template
+    value_template: >-
+      {{ light_enabled and light_entity != ''
+         and states(light_entity) | float(1000) > max_light }}
+    for:
+      minutes: !input light_for
+    id: light_max
+
+  # UV index
+  - trigger: template
+    value_template: >-
+      {{ uv_enabled and uv_entity != ''
+         and states(uv_entity) | float(0) > max_uv }}
+    for:
+      minutes: !input uv_for
+    id: uv_max
+
+  # Battery (PLT-1B only)
+  - trigger: template
+    value_template: >-
+      {{ battery_enabled and battery_entity != ''
+         and states(battery_entity) | float(100) < min_battery }}
+    for:
+      minutes: !input battery_for
+    id: battery_min
+
+conditions:
+  - condition: template
+    value_template: "{{ time_hours != 'none' or trigger.id != 'time' }}"
+
+action:
+  # Soil Moisture — Low
+  - alias: Soil Moisture Low Alert
+    if:
+      - condition: template
+        value_template: >-
+          {{ soil_moisture_enabled and soil_moisture_entity != ''
+             and states(soil_moisture_entity) | float(50) < min_soil_moisture
+             and trigger.id in ['time', 'soil_moisture_min'] }}
+    then:
+      - if:
+          - condition: template
+            value_template: "{{ notify_device is not none and notify_device != '' }}"
+        then:
+          - device_id: !input notify_device
+            domain: mobile_app
+            type: notify
+            title: "{{ plant_name }} — Soil Moisture Low"
+            message: >-
+              Soil moisture is {{ states(soil_moisture_entity) | round(1) }}%,
+              below the minimum of {{ min_soil_moisture }}%. Time to water!
+            data: "{{ device_message_data }}"
+      - !input custom_action
+
+  # Soil Moisture — High
+  - alias: Soil Moisture High Alert
+    if:
+      - condition: template
+        value_template: >-
+          {{ soil_moisture_enabled and soil_moisture_entity != ''
+             and states(soil_moisture_entity) | float(50) > max_soil_moisture
+             and trigger.id in ['time', 'soil_moisture_max'] }}
+    then:
+      - if:
+          - condition: template
+            value_template: "{{ notify_device is not none and notify_device != '' }}"
+        then:
+          - device_id: !input notify_device
+            domain: mobile_app
+            type: notify
+            title: "{{ plant_name }} — Soil Moisture High"
+            message: >-
+              Soil moisture is {{ states(soil_moisture_entity) | round(1) }}%,
+              above the maximum of {{ max_soil_moisture }}%. Risk of overwatering!
+            data: "{{ device_message_data }}"
+      - !input custom_action
+
+  # Soil Temperature — Low
+  - alias: Soil Temperature Low Alert
+    if:
+      - condition: template
+        value_template: >-
+          {{ soil_temp_enabled and soil_temp_entity != ''
+             and states(soil_temp_entity) | float(20) < min_soil_temp
+             and trigger.id in ['time', 'soil_temp_min'] }}
+    then:
+      - if:
+          - condition: template
+            value_template: "{{ notify_device is not none and notify_device != '' }}"
+        then:
+          - device_id: !input notify_device
+            domain: mobile_app
+            type: notify
+            title: "{{ plant_name }} — Soil Too Cold"
+            message: >-
+              Soil temperature is {{ states(soil_temp_entity) | round(1) }}{{ state_attr(soil_temp_entity, 'unit_of_measurement') }},
+              below the minimum of {{ min_soil_temp }}{{ state_attr(soil_temp_entity, 'unit_of_measurement') }}.
+              Roots may be too cold!
+            data: "{{ device_message_data }}"
+      - !input custom_action
+
+  # Soil Temperature — High
+  - alias: Soil Temperature High Alert
+    if:
+      - condition: template
+        value_template: >-
+          {{ soil_temp_enabled and soil_temp_entity != ''
+             and states(soil_temp_entity) | float(20) > max_soil_temp
+             and trigger.id in ['time', 'soil_temp_max'] }}
+    then:
+      - if:
+          - condition: template
+            value_template: "{{ notify_device is not none and notify_device != '' }}"
+        then:
+          - device_id: !input notify_device
+            domain: mobile_app
+            type: notify
+            title: "{{ plant_name }} — Soil Too Hot"
+            message: >-
+              Soil temperature is {{ states(soil_temp_entity) | round(1) }}{{ state_attr(soil_temp_entity, 'unit_of_measurement') }},
+              above the maximum of {{ max_soil_temp }}{{ state_attr(soil_temp_entity, 'unit_of_measurement') }}.
+              Roots may overheat!
+            data: "{{ device_message_data }}"
+      - !input custom_action
+
+  # Air Temperature — Low
+  - alias: Air Temperature Low Alert
+    if:
+      - condition: template
+        value_template: >-
+          {{ air_temp_enabled and air_temp_entity != ''
+             and states(air_temp_entity) | float(20) < min_air_temp
+             and trigger.id in ['time', 'air_temp_min'] }}
+    then:
+      - if:
+          - condition: template
+            value_template: "{{ notify_device is not none and notify_device != '' }}"
+        then:
+          - device_id: !input notify_device
+            domain: mobile_app
+            type: notify
+            title: "{{ plant_name }} — Air Too Cold"
+            message: >-
+              Air temperature is {{ states(air_temp_entity) | round(1) }}{{ state_attr(air_temp_entity, 'unit_of_measurement') }},
+              below the minimum of {{ min_air_temp }}{{ state_attr(air_temp_entity, 'unit_of_measurement') }}.
+              Environment may be too cold!
+            data: "{{ device_message_data }}"
+      - !input custom_action
+
+  # Air Temperature — High
+  - alias: Air Temperature High Alert
+    if:
+      - condition: template
+        value_template: >-
+          {{ air_temp_enabled and air_temp_entity != ''
+             and states(air_temp_entity) | float(20) > max_air_temp
+             and trigger.id in ['time', 'air_temp_max'] }}
+    then:
+      - if:
+          - condition: template
+            value_template: "{{ notify_device is not none and notify_device != '' }}"
+        then:
+          - device_id: !input notify_device
+            domain: mobile_app
+            type: notify
+            title: "{{ plant_name }} — Air Too Hot"
+            message: >-
+              Air temperature is {{ states(air_temp_entity) | round(1) }}{{ state_attr(air_temp_entity, 'unit_of_measurement') }},
+              above the maximum of {{ max_air_temp }}{{ state_attr(air_temp_entity, 'unit_of_measurement') }}.
+              Environment may be too hot!
+            data: "{{ device_message_data }}"
+      - !input custom_action
+
+  # Air Humidity — Low
+  - alias: Air Humidity Low Alert
+    if:
+      - condition: template
+        value_template: >-
+          {{ air_humidity_enabled and air_humidity_entity != ''
+             and states(air_humidity_entity) | float(50) < min_air_humidity
+             and trigger.id in ['time', 'air_humidity_min'] }}
+    then:
+      - if:
+          - condition: template
+            value_template: "{{ notify_device is not none and notify_device != '' }}"
+        then:
+          - device_id: !input notify_device
+            domain: mobile_app
+            type: notify
+            title: "{{ plant_name }} — Air Too Dry"
+            message: >-
+              Air humidity is {{ states(air_humidity_entity) | round(1) }}%,
+              below the minimum of {{ min_air_humidity }}%.
+              Dry air can stress your plant!
+            data: "{{ device_message_data }}"
+      - !input custom_action
+
+  # Air Humidity — High
+  - alias: Air Humidity High Alert
+    if:
+      - condition: template
+        value_template: >-
+          {{ air_humidity_enabled and air_humidity_entity != ''
+             and states(air_humidity_entity) | float(50) > max_air_humidity
+             and trigger.id in ['time', 'air_humidity_max'] }}
+    then:
+      - if:
+          - condition: template
+            value_template: "{{ notify_device is not none and notify_device != '' }}"
+        then:
+          - device_id: !input notify_device
+            domain: mobile_app
+            type: notify
+            title: "{{ plant_name }} — Humidity Too High"
+            message: >-
+              Air humidity is {{ states(air_humidity_entity) | round(1) }}%,
+              above the maximum of {{ max_air_humidity }}%.
+              Risk of mold or rot!
+            data: "{{ device_message_data }}"
+      - !input custom_action
+
+  # Light — Too Dark
+  - alias: Light Too Low Alert
+    if:
+      - condition: template
+        value_template: >-
+          {{ light_enabled and light_entity != ''
+             and states(light_entity) | float(1000) < min_light
+             and trigger.id in ['time', 'light_min'] }}
+    then:
+      - if:
+          - condition: template
+            value_template: "{{ notify_device is not none and notify_device != '' }}"
+        then:
+          - device_id: !input notify_device
+            domain: mobile_app
+            type: notify
+            title: "{{ plant_name }} — Not Enough Light"
+            message: >-
+              Light level is {{ states(light_entity) | round(0) }} lux,
+              below the minimum of {{ min_light }} lux.
+              Move to a brighter spot!
+            data: "{{ device_message_data }}"
+      - !input custom_action
+
+  # Light — Too Bright
+  - alias: Light Too High Alert
+    if:
+      - condition: template
+        value_template: >-
+          {{ light_enabled and light_entity != ''
+             and states(light_entity) | float(1000) > max_light
+             and trigger.id in ['time', 'light_max'] }}
+    then:
+      - if:
+          - condition: template
+            value_template: "{{ notify_device is not none and notify_device != '' }}"
+        then:
+          - device_id: !input notify_device
+            domain: mobile_app
+            type: notify
+            title: "{{ plant_name }} — Too Much Light"
+            message: >-
+              Light level is {{ states(light_entity) | round(0) }} lux,
+              above the maximum of {{ max_light }} lux.
+              Direct sun may scorch leaves!
+            data: "{{ device_message_data }}"
+      - !input custom_action
+
+  # UV Index — High
+  - alias: UV Index High Alert
+    if:
+      - condition: template
+        value_template: >-
+          {{ uv_enabled and uv_entity != ''
+             and states(uv_entity) | float(0) > max_uv
+             and trigger.id in ['time', 'uv_max'] }}
+    then:
+      - if:
+          - condition: template
+            value_template: "{{ notify_device is not none and notify_device != '' }}"
+        then:
+          - device_id: !input notify_device
+            domain: mobile_app
+            type: notify
+            title: "{{ plant_name }} — UV Index High"
+            message: >-
+              UV index is {{ states(uv_entity) | round(1) }},
+              above the maximum of {{ max_uv }}.
+              Excessive UV exposure!
+            data: "{{ device_message_data }}"
+      - !input custom_action
+
+  # Battery — Low (PLT-1B only)
+  - alias: Battery Low Alert
+    if:
+      - condition: template
+        value_template: >-
+          {{ battery_enabled and battery_entity != ''
+             and states(battery_entity) | float(100) < min_battery
+             and trigger.id in ['time', 'battery_min'] }}
+    then:
+      - if:
+          - condition: template
+            value_template: "{{ notify_device is not none and notify_device != '' }}"
+        then:
+          - device_id: !input notify_device
+            domain: mobile_app
+            type: notify
+            title: "{{ plant_name }} — Sensor Battery Low"
+            message: >-
+              Sensor battery is {{ states(battery_entity) | round(0) }}%,
+              below the minimum of {{ min_battery }}%.
+              Please recharge!
+            data: "{{ device_message_data }}"
+      - !input custom_action
+
+mode: parallel
+max: 10

--- a/PLT-1/PLT-1.yaml
+++ b/PLT-1/PLT-1.yaml
@@ -133,6 +133,15 @@ blueprint:
         Alerts also fire immediately when a threshold is first crossed.
       icon: mdi:clock-alert
       input:
+        disable_repeat:
+          name: Disable Repeat Alerts
+          description: >
+            When enabled, alerts fire only once per threshold crossing and
+            are never re-sent on a schedule.
+          default: false
+          selector:
+            boolean:
+
         time_hours:
           name: Repeat — Hours
           description: How often (by hour) to re-send alerts when conditions persist.
@@ -151,8 +160,6 @@ blueprint:
                   value: "/6"
                 - label: "Every 12 Hours"
                   value: "/12"
-                - label: "Never (disable repeat)"
-                  value: "none"
 
         time_minutes:
           name: Repeat — Minutes
@@ -541,6 +548,7 @@ trigger_variables:
     {{ message.data }}
 
   time_hours: !input time_hours
+  disable_repeat: !input disable_repeat
 
 # ── Triggers ─────────────────────────────────────────────────────────────────────
 triggers:
@@ -554,7 +562,8 @@ triggers:
   - trigger: template
     value_template: >-
       {{ soil_moisture_enabled and soil_moisture_entity != ''
-         and states(soil_moisture_entity) | float(50) < min_soil_moisture }}
+         and is_number(states(soil_moisture_entity))
+         and states(soil_moisture_entity) | float < min_soil_moisture }}
     for:
       minutes: !input soil_moisture_for
     id: soil_moisture_min
@@ -562,7 +571,8 @@ triggers:
   - trigger: template
     value_template: >-
       {{ soil_moisture_enabled and soil_moisture_entity != ''
-         and states(soil_moisture_entity) | float(50) > max_soil_moisture }}
+         and is_number(states(soil_moisture_entity))
+         and states(soil_moisture_entity) | float > max_soil_moisture }}
     for:
       minutes: !input soil_moisture_for
     id: soil_moisture_max
@@ -571,7 +581,8 @@ triggers:
   - trigger: template
     value_template: >-
       {{ soil_temp_enabled and soil_temp_entity != ''
-         and states(soil_temp_entity) | float(20) < min_soil_temp }}
+         and is_number(states(soil_temp_entity))
+         and states(soil_temp_entity) | float < min_soil_temp }}
     for:
       minutes: !input soil_temp_for
     id: soil_temp_min
@@ -579,7 +590,8 @@ triggers:
   - trigger: template
     value_template: >-
       {{ soil_temp_enabled and soil_temp_entity != ''
-         and states(soil_temp_entity) | float(20) > max_soil_temp }}
+         and is_number(states(soil_temp_entity))
+         and states(soil_temp_entity) | float > max_soil_temp }}
     for:
       minutes: !input soil_temp_for
     id: soil_temp_max
@@ -588,7 +600,8 @@ triggers:
   - trigger: template
     value_template: >-
       {{ air_temp_enabled and air_temp_entity != ''
-         and states(air_temp_entity) | float(20) < min_air_temp }}
+         and is_number(states(air_temp_entity))
+         and states(air_temp_entity) | float < min_air_temp }}
     for:
       minutes: !input air_temp_for
     id: air_temp_min
@@ -596,7 +609,8 @@ triggers:
   - trigger: template
     value_template: >-
       {{ air_temp_enabled and air_temp_entity != ''
-         and states(air_temp_entity) | float(20) > max_air_temp }}
+         and is_number(states(air_temp_entity))
+         and states(air_temp_entity) | float > max_air_temp }}
     for:
       minutes: !input air_temp_for
     id: air_temp_max
@@ -605,7 +619,8 @@ triggers:
   - trigger: template
     value_template: >-
       {{ air_humidity_enabled and air_humidity_entity != ''
-         and states(air_humidity_entity) | float(50) < min_air_humidity }}
+         and is_number(states(air_humidity_entity))
+         and states(air_humidity_entity) | float < min_air_humidity }}
     for:
       minutes: !input air_humidity_for
     id: air_humidity_min
@@ -613,7 +628,8 @@ triggers:
   - trigger: template
     value_template: >-
       {{ air_humidity_enabled and air_humidity_entity != ''
-         and states(air_humidity_entity) | float(50) > max_air_humidity }}
+         and is_number(states(air_humidity_entity))
+         and states(air_humidity_entity) | float > max_air_humidity }}
     for:
       minutes: !input air_humidity_for
     id: air_humidity_max
@@ -622,7 +638,8 @@ triggers:
   - trigger: template
     value_template: >-
       {{ light_enabled and light_entity != ''
-         and states(light_entity) | float(1000) < min_light }}
+         and is_number(states(light_entity))
+         and states(light_entity) | float < min_light }}
     for:
       minutes: !input light_for
     id: light_min
@@ -630,7 +647,8 @@ triggers:
   - trigger: template
     value_template: >-
       {{ light_enabled and light_entity != ''
-         and states(light_entity) | float(1000) > max_light }}
+         and is_number(states(light_entity))
+         and states(light_entity) | float > max_light }}
     for:
       minutes: !input light_for
     id: light_max
@@ -639,7 +657,8 @@ triggers:
   - trigger: template
     value_template: >-
       {{ uv_enabled and uv_entity != ''
-         and states(uv_entity) | float(0) > max_uv }}
+         and is_number(states(uv_entity))
+         and states(uv_entity) | float > max_uv }}
     for:
       minutes: !input uv_for
     id: uv_max
@@ -648,14 +667,15 @@ triggers:
   - trigger: template
     value_template: >-
       {{ battery_enabled and battery_entity != ''
-         and states(battery_entity) | float(100) < min_battery }}
+         and is_number(states(battery_entity))
+         and states(battery_entity) | float < min_battery }}
     for:
       minutes: !input battery_for
     id: battery_min
 
 conditions:
   - condition: template
-    value_template: "{{ time_hours != 'none' or trigger.id != 'time' }}"
+    value_template: "{{ not disable_repeat or trigger.id != 'time' }}"
 
 action:
   # Soil Moisture — Low
@@ -664,7 +684,8 @@ action:
       - condition: template
         value_template: >-
           {{ soil_moisture_enabled and soil_moisture_entity != ''
-             and states(soil_moisture_entity) | float(50) < min_soil_moisture
+             and is_number(states(soil_moisture_entity))
+             and states(soil_moisture_entity) | float < min_soil_moisture
              and trigger.id in ['time', 'soil_moisture_min'] }}
     then:
       - if:
@@ -676,7 +697,7 @@ action:
             type: notify
             title: "{{ plant_name }} — Soil Moisture Low"
             message: >-
-              Soil moisture is {{ states(soil_moisture_entity) | round(1) }}%,
+              Soil moisture is {{ states(soil_moisture_entity) | float(0) | round(1) }}%,
               below the minimum of {{ min_soil_moisture }}%. Time to water!
             data: "{{ device_message_data }}"
       - !input custom_action
@@ -687,7 +708,8 @@ action:
       - condition: template
         value_template: >-
           {{ soil_moisture_enabled and soil_moisture_entity != ''
-             and states(soil_moisture_entity) | float(50) > max_soil_moisture
+             and is_number(states(soil_moisture_entity))
+             and states(soil_moisture_entity) | float > max_soil_moisture
              and trigger.id in ['time', 'soil_moisture_max'] }}
     then:
       - if:
@@ -699,7 +721,7 @@ action:
             type: notify
             title: "{{ plant_name }} — Soil Moisture High"
             message: >-
-              Soil moisture is {{ states(soil_moisture_entity) | round(1) }}%,
+              Soil moisture is {{ states(soil_moisture_entity) | float(0) | round(1) }}%,
               above the maximum of {{ max_soil_moisture }}%. Risk of overwatering!
             data: "{{ device_message_data }}"
       - !input custom_action
@@ -710,7 +732,8 @@ action:
       - condition: template
         value_template: >-
           {{ soil_temp_enabled and soil_temp_entity != ''
-             and states(soil_temp_entity) | float(20) < min_soil_temp
+             and is_number(states(soil_temp_entity))
+             and states(soil_temp_entity) | float < min_soil_temp
              and trigger.id in ['time', 'soil_temp_min'] }}
     then:
       - if:
@@ -722,7 +745,7 @@ action:
             type: notify
             title: "{{ plant_name }} — Soil Too Cold"
             message: >-
-              Soil temperature is {{ states(soil_temp_entity) | round(1) }}{{ state_attr(soil_temp_entity, 'unit_of_measurement') }},
+              Soil temperature is {{ states(soil_temp_entity) | float(0) | round(1) }}{{ state_attr(soil_temp_entity, 'unit_of_measurement') }},
               below the minimum of {{ min_soil_temp }}{{ state_attr(soil_temp_entity, 'unit_of_measurement') }}.
               Roots may be too cold!
             data: "{{ device_message_data }}"
@@ -734,7 +757,8 @@ action:
       - condition: template
         value_template: >-
           {{ soil_temp_enabled and soil_temp_entity != ''
-             and states(soil_temp_entity) | float(20) > max_soil_temp
+             and is_number(states(soil_temp_entity))
+             and states(soil_temp_entity) | float > max_soil_temp
              and trigger.id in ['time', 'soil_temp_max'] }}
     then:
       - if:
@@ -746,7 +770,7 @@ action:
             type: notify
             title: "{{ plant_name }} — Soil Too Hot"
             message: >-
-              Soil temperature is {{ states(soil_temp_entity) | round(1) }}{{ state_attr(soil_temp_entity, 'unit_of_measurement') }},
+              Soil temperature is {{ states(soil_temp_entity) | float(0) | round(1) }}{{ state_attr(soil_temp_entity, 'unit_of_measurement') }},
               above the maximum of {{ max_soil_temp }}{{ state_attr(soil_temp_entity, 'unit_of_measurement') }}.
               Roots may overheat!
             data: "{{ device_message_data }}"
@@ -758,7 +782,8 @@ action:
       - condition: template
         value_template: >-
           {{ air_temp_enabled and air_temp_entity != ''
-             and states(air_temp_entity) | float(20) < min_air_temp
+             and is_number(states(air_temp_entity))
+             and states(air_temp_entity) | float < min_air_temp
              and trigger.id in ['time', 'air_temp_min'] }}
     then:
       - if:
@@ -770,7 +795,7 @@ action:
             type: notify
             title: "{{ plant_name }} — Air Too Cold"
             message: >-
-              Air temperature is {{ states(air_temp_entity) | round(1) }}{{ state_attr(air_temp_entity, 'unit_of_measurement') }},
+              Air temperature is {{ states(air_temp_entity) | float(0) | round(1) }}{{ state_attr(air_temp_entity, 'unit_of_measurement') }},
               below the minimum of {{ min_air_temp }}{{ state_attr(air_temp_entity, 'unit_of_measurement') }}.
               Environment may be too cold!
             data: "{{ device_message_data }}"
@@ -782,7 +807,8 @@ action:
       - condition: template
         value_template: >-
           {{ air_temp_enabled and air_temp_entity != ''
-             and states(air_temp_entity) | float(20) > max_air_temp
+             and is_number(states(air_temp_entity))
+             and states(air_temp_entity) | float > max_air_temp
              and trigger.id in ['time', 'air_temp_max'] }}
     then:
       - if:
@@ -794,7 +820,7 @@ action:
             type: notify
             title: "{{ plant_name }} — Air Too Hot"
             message: >-
-              Air temperature is {{ states(air_temp_entity) | round(1) }}{{ state_attr(air_temp_entity, 'unit_of_measurement') }},
+              Air temperature is {{ states(air_temp_entity) | float(0) | round(1) }}{{ state_attr(air_temp_entity, 'unit_of_measurement') }},
               above the maximum of {{ max_air_temp }}{{ state_attr(air_temp_entity, 'unit_of_measurement') }}.
               Environment may be too hot!
             data: "{{ device_message_data }}"
@@ -806,7 +832,8 @@ action:
       - condition: template
         value_template: >-
           {{ air_humidity_enabled and air_humidity_entity != ''
-             and states(air_humidity_entity) | float(50) < min_air_humidity
+             and is_number(states(air_humidity_entity))
+             and states(air_humidity_entity) | float < min_air_humidity
              and trigger.id in ['time', 'air_humidity_min'] }}
     then:
       - if:
@@ -818,7 +845,7 @@ action:
             type: notify
             title: "{{ plant_name }} — Air Too Dry"
             message: >-
-              Air humidity is {{ states(air_humidity_entity) | round(1) }}%,
+              Air humidity is {{ states(air_humidity_entity) | float(0) | round(1) }}%,
               below the minimum of {{ min_air_humidity }}%.
               Dry air can stress your plant!
             data: "{{ device_message_data }}"
@@ -830,7 +857,8 @@ action:
       - condition: template
         value_template: >-
           {{ air_humidity_enabled and air_humidity_entity != ''
-             and states(air_humidity_entity) | float(50) > max_air_humidity
+             and is_number(states(air_humidity_entity))
+             and states(air_humidity_entity) | float > max_air_humidity
              and trigger.id in ['time', 'air_humidity_max'] }}
     then:
       - if:
@@ -842,7 +870,7 @@ action:
             type: notify
             title: "{{ plant_name }} — Humidity Too High"
             message: >-
-              Air humidity is {{ states(air_humidity_entity) | round(1) }}%,
+              Air humidity is {{ states(air_humidity_entity) | float(0) | round(1) }}%,
               above the maximum of {{ max_air_humidity }}%.
               Risk of mold or rot!
             data: "{{ device_message_data }}"
@@ -854,7 +882,8 @@ action:
       - condition: template
         value_template: >-
           {{ light_enabled and light_entity != ''
-             and states(light_entity) | float(1000) < min_light
+             and is_number(states(light_entity))
+             and states(light_entity) | float < min_light
              and trigger.id in ['time', 'light_min'] }}
     then:
       - if:
@@ -866,7 +895,7 @@ action:
             type: notify
             title: "{{ plant_name }} — Not Enough Light"
             message: >-
-              Light level is {{ states(light_entity) | round(0) }} lux,
+              Light level is {{ states(light_entity) | float(0) | round(0) }} lux,
               below the minimum of {{ min_light }} lux.
               Move to a brighter spot!
             data: "{{ device_message_data }}"
@@ -878,7 +907,8 @@ action:
       - condition: template
         value_template: >-
           {{ light_enabled and light_entity != ''
-             and states(light_entity) | float(1000) > max_light
+             and is_number(states(light_entity))
+             and states(light_entity) | float > max_light
              and trigger.id in ['time', 'light_max'] }}
     then:
       - if:
@@ -890,7 +920,7 @@ action:
             type: notify
             title: "{{ plant_name }} — Too Much Light"
             message: >-
-              Light level is {{ states(light_entity) | round(0) }} lux,
+              Light level is {{ states(light_entity) | float(0) | round(0) }} lux,
               above the maximum of {{ max_light }} lux.
               Direct sun may scorch leaves!
             data: "{{ device_message_data }}"
@@ -902,7 +932,8 @@ action:
       - condition: template
         value_template: >-
           {{ uv_enabled and uv_entity != ''
-             and states(uv_entity) | float(0) > max_uv
+             and is_number(states(uv_entity))
+             and states(uv_entity) | float > max_uv
              and trigger.id in ['time', 'uv_max'] }}
     then:
       - if:
@@ -914,7 +945,7 @@ action:
             type: notify
             title: "{{ plant_name }} — UV Index High"
             message: >-
-              UV index is {{ states(uv_entity) | round(1) }},
+              UV index is {{ states(uv_entity) | float(0) | round(1) }},
               above the maximum of {{ max_uv }}.
               Excessive UV exposure!
             data: "{{ device_message_data }}"
@@ -926,7 +957,8 @@ action:
       - condition: template
         value_template: >-
           {{ battery_enabled and battery_entity != ''
-             and states(battery_entity) | float(100) < min_battery
+             and is_number(states(battery_entity))
+             and states(battery_entity) | float < min_battery
              and trigger.id in ['time', 'battery_min'] }}
     then:
       - if:
@@ -938,7 +970,7 @@ action:
             type: notify
             title: "{{ plant_name }} — Sensor Battery Low"
             message: >-
-              Sensor battery is {{ states(battery_entity) | round(0) }}%,
+              Sensor battery is {{ states(battery_entity) | float(0) | round(0) }}%,
               below the minimum of {{ min_battery }}%.
               Please recharge!
             data: "{{ device_message_data }}"

--- a/PLT-1/PLT-1.yaml
+++ b/PLT-1/PLT-1.yaml
@@ -1,22 +1,25 @@
 blueprint:
-  name: Apollo PLT-1 Plant Sensor Alerts
+  name: Apollo Automation PLT-1 Blueprint
   source_url: https://github.com/ApolloAutomation/Blueprints/blob/main/PLT-1/PLT-1.yaml
   author: ApolloAutomation
   description: >
-    Receive alerts when your Apollo Automation PLT-1 or PLT-1B plant sensor
-    detects soil moisture, temperature, humidity, light, UV, or battery levels
-    outside your configured thresholds.
+    🌱 Receive mobile alerts when your Apollo Automation PLT-1 or PLT-1B plant
+    sensor detects conditions outside your configured thresholds.
 
-    Works with both the **PLT-1** (wired) and **PLT-1B** (battery) models.
+    🪴 Works with both the **PLT-1** (wired) and **PLT-1B** (battery) models.
 
-    [Click here](https://wiki.apolloautomation.com) to learn more about the PLT-1
-    and recommended threshold values for common houseplants.
+    📖 [Click here](https://wiki.apolloautomation.com) to learn more about the
+    PLT-1 and recommended threshold values for common houseplants.
 
     **Setup:**
-    1. Select your PLT-1 or PLT-1B device
-    2. Enter your plant's name
-    3. Configure your notification device and options
-    4. Enable each sensor group you want to monitor and adjust thresholds
+
+    1️⃣ Select your PLT-1 or PLT-1B device
+
+    2️⃣ Enter your plant's name
+
+    3️⃣ Configure your notification device and options
+
+    4️⃣ Enable each sensor group you want to monitor and adjust thresholds
   domain: automation
   homeassistant:
     min_version: "2024.6.0"

--- a/PLT-1/PLT-1.yaml
+++ b/PLT-1/PLT-1.yaml
@@ -533,7 +533,7 @@ trigger_variables:
       {% set message.data = dict(message.data, **{ 'ttl': 0, 'priority': 'high' }) %}
     {% endif %}
     {% if 'sticky' in notify_data %}
-      {% set message.data = dict(message.data, **{ 'sticky': "true" }) %}
+      {% set message.data = dict(message.data, **{ 'sticky': true }) %}
     {% endif %}
     {% if 'channel' in notify_data and notify_channel != '' %}
       {% set message.data = dict(message.data, **{ 'channel': notify_channel }) %}

--- a/PLT-1/PLT-1.yaml
+++ b/PLT-1/PLT-1.yaml
@@ -215,8 +215,7 @@ blueprint:
         on your device (Settings → Devices & Services → your PLT-1 → enable
         Soil ADC), record the raw voltage with the probe dry in air, then
         again with the probe submerged in water up to the Apollo label only.
-        Disable Soil ADC again when done — especially important on the PLT-1B
-        to preserve battery life.
+        Disable Soil ADC again when done.
       icon: mdi:tune-variant
       input:
         dry_voltage_value:

--- a/PLT-1/README.md
+++ b/PLT-1/README.md
@@ -1,0 +1,115 @@
+# Apollo PLT-1 Plant Sensor Alerts
+
+[![Import Blueprint](https://my.home-assistant.io/badges/blueprint_import.svg)](https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fgithub.com%2FApolloAutomation%2FBlueprints%2Fblob%2Fmain%2FPLT-1%2FPLT-1.yaml)
+
+Receive mobile push notifications and trigger custom actions when your **Apollo Automation PLT-1** or **PLT-1B** plant sensor detects conditions outside your configured thresholds.
+
+---
+
+## Supported Sensors
+
+| Sensor | Alert Types | Default Thresholds |
+|---|---|---|
+| Soil Moisture | Low (needs watering) / High (overwatered) | 20% – 80% |
+| Soil Temperature | Too cold / Too hot | 10°C – 30°C |
+| Air Temperature | Too cold / Too hot | 15°C – 32°C |
+| Air Humidity | Too dry / Too humid | 30% – 80% |
+| Light Intensity | Too dark / Too bright | 100 – 50,000 lux |
+| UV Index | Too high | > 6 |
+| Battery Level | Low *(PLT-1B only)* | < 20% |
+
+Each sensor group is **disabled by default** (except Soil Moisture) so you can monitor only what matters for your plants.
+
+---
+
+## Requirements
+
+- **Apollo Automation PLT-1 or PLT-1B** connected to Home Assistant via ESPHome
+- Home Assistant **2024.6.0** or newer
+- Home Assistant Companion App installed on your phone *(for mobile push notifications)*
+
+---
+
+## Setup
+
+1. Click the **Import Blueprint** badge above, or copy the URL and paste it into
+   **Settings → Automations & Scenes → Blueprints → Import Blueprint**
+
+2. Create a new automation from the blueprint
+
+3. **Select your PLT-1 device** from the dropdown — the blueprint automatically finds all sensor entities
+
+4. Enter your **plant's name** (appears in notification messages)
+
+5. Select your **mobile device** for push notifications (optional — you can use a Custom Action instead)
+
+6. Expand the sensor groups you want to monitor, enable them, and adjust the thresholds to suit your plant
+
+7. *(Optional)* Expand **Repeat Alerts** to configure how often you get reminded while a condition persists
+
+---
+
+## Input Reference
+
+### Device
+
+| Input | Description | Default |
+|---|---|---|
+| PLT-1 Device | Your PLT-1 or PLT-1B device | — |
+| Plant Name | Used in notification messages | `My Plant` |
+
+### Notifications
+
+| Input | Description | Default |
+|---|---|---|
+| Notify Device | Mobile device (Companion App) | *(optional)* |
+| Interruption Level | iOS notification urgency | `active` |
+| Android Options | High priority, sticky, or channel | *(optional)* |
+| Custom Action | Any HA action (TTS, lights, email…) | *(optional)* |
+
+### Repeat Alerts
+
+| Input | Description | Default |
+|---|---|---|
+| Repeat — Hours | How often to re-alert while condition persists | Every Hour |
+| Repeat — Minutes | Minute offset for repeat schedule | At :01 |
+
+Set **Hours** to `Never (disable repeat)` to receive only one alert per threshold crossing.
+
+### Per-Sensor Inputs
+
+Each sensor group (Soil Moisture, Soil Temperature, Air Temperature, Air Humidity, Light Intensity, UV Index, Battery) shares the same pattern:
+
+| Input | Description |
+|---|---|
+| Enable Alerts | Toggle — enable or disable this sensor group |
+| Minimum threshold | Alert when value drops below this level |
+| Maximum threshold | Alert when value rises above this level *(where applicable)* |
+| Alert Delay (minutes) | How long the condition must persist before firing — prevents false alerts |
+
+---
+
+## Alert Behaviour
+
+- **Immediate alert**: fires as soon as the threshold is exceeded for the configured delay duration
+- **Repeat alert**: the repeat schedule re-sends the alert while the condition persists
+- **Deduplication**: the automation is set to `parallel` mode, so multiple sensors can alert simultaneously without blocking each other
+
+---
+
+## Compatible Devices
+
+| Model | Wired/Battery | Battery Alerts |
+|---|---|---|
+| PLT-1 | Wired (USB) | Not applicable |
+| PLT-1B | Battery (Li-ion) | Yes — enable in **Battery** section |
+
+---
+
+## Resources
+
+- [PLT-1 Product Page](https://apolloautomation.com)
+- [PLT-1 Wiki & Documentation](https://wiki.apolloautomation.com)
+- [Apollo Automation Discord](https://apolloautomation.com/discord)
+- [GitHub — PLT-1 Firmware](https://github.com/ApolloAutomation/PLT-1)
+- [Apollo Automation Blueprints](https://github.com/ApolloAutomation/Blueprints)


### PR DESCRIPTION
## Summary

Adds a Home Assistant automation blueprint for the **Apollo Automation PLT-1** and **PLT-1B** plant sensors, following the same patterns as the existing AIR-1 blueprint.

- **Sensors covered**: Soil moisture, soil temperature, air temperature, air humidity, light intensity, UV index, and battery level (PLT-1B)
- **Both models supported**: Single device selector auto-discovers entities for PLT-1 (wired) and PLT-1B (battery)
- **Per-sensor control**: Each sensor group has an enable toggle, configurable low/high thresholds, and an alert delay to prevent false alarms from brief fluctuations
- **Notifications**: Mobile push via Companion App (with iOS interruption levels + Android priority/sticky options) + optional custom action slot for TTS, lights, email, etc.
- **Repeat alerts**: Configurable hourly repeat schedule while conditions persist (matches AIR-1 pattern)

## Files

- `PLT-1/PLT-1.yaml` — Blueprint (948 lines)
- `PLT-1/README.md` — Documentation with import badge, sensor table, setup guide, and input reference

## One-Click Import

[![Import Blueprint](https://my.home-assistant.io/badges/blueprint_import.svg)](https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fgithub.com%2FApolloAutomation%2FBlueprints%2Fblob%2Fmain%2FPLT-1%2FPLT-1.yaml)

## Test plan

- [ ] Import blueprint via one-click URL — verify all input sections render correctly
- [ ] Select PLT-1 device — confirm entity discovery resolves all sensor entities
- [ ] Select PLT-1B device — confirm battery entity also resolves
- [ ] Enable Soil Moisture, lower threshold below current reading — confirm immediate alert fires after configured delay
- [ ] Enable repeat alerts — confirm re-alert fires on schedule while condition persists
- [ ] Test with no notify_device configured — confirm custom_action still fires without errors
- [ ] Test with custom_action set — confirm it fires alongside mobile notification

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Apollo PLT-1 Plant Sensor Alerts blueprint for Home Assistant with per-sensor enable/threshold controls, calibration support, repeat reminders, PLT-1B battery monitoring, and concurrent handling (up to 10 actions).

* **Notifications**
  * Configurable mobile push options (interruption level, Android channel/TTL), device targets, templated alert titles/messages, and optional custom actions.

* **Documentation**
  * Added README detailing supported sensors, defaults, setup steps, inputs, and alert behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->