### PR TITLE
fix: set sticky notification to boolean true in AIR-1

### DIFF
--- a/AIR-1/AIR-1.yaml
+++ b/AIR-1/AIR-1.yaml
@@ -448,7 +448,7 @@ trigger_variables:
       {% set message.data = dict(message.data, **{ 'ttl': 0, 'priority': 'high' }) %}
     {% endif %}
     {% if 'sticky' in notify_data %}
-      {% set message.data = dict(message.data, **{ 'sticky': "true" }) %}
+      {% set message.data = dict(message.data, **{ 'sticky': true }) %}
     {% endif %}
     {{ message.data }}
 


### PR DESCRIPTION
## Summary

The `device_message_data` Jinja helper in `AIR-1.yaml` sets the `sticky` notification flag as the string `"true"` rather than a boolean. The HA Companion App expects a boolean for this field.

## Change

```diff
-      {% set message.data = dict(message.data, **{ 'sticky': "true" }) %}
+      {% set message.data = dict(message.data, **{ 'sticky': true }) %}
```

This is a one-line fix, no logic changes. The same fix was applied to the PLT-1 blueprint in #14.

## Test plan

- [ ] Enable "Sticky Notification" option in an AIR-1 automation, trigger an alert — confirm notification remains visible after tapping (Android)
- [ ] YAML still valid: `python3 -c "import yaml; yaml.safe_load(open('AIR-1/AIR-1.yaml'))"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)