### PR TITLE
Add CAST-1 WizMote blueprint

### DIFF
--- a/CAST-1/CAST-1-WizMote.yaml
+++ b/CAST-1/CAST-1-WizMote.yaml
@@ -1,0 +1,331 @@
+blueprint:
+  name: Apollo CAST-1 WizMote
+  description: |
+    Make your WizMote control the Apollo CAST-1 exactly how you want.
+
+    **Features**
+
+    - 🎵 Every button ships with a default (Play, Pause, Volume, Next, Previous) - override any of them by picking another option from its dropdown
+    - 🏠 Or set a button to "Send HA Event" to set up a custom action instead!
+
+    What's "Send HA Event"? It passes the press to Home Assistant so it can do anything HA can, for example:
+
+    - ▶️ Play a Music Assistant playlist
+    - 💡 Toggle a room's lights
+    - 🎬 Run a scene or script
+  domain: automation
+  source_url: https://github.com/ApolloAutomation/Blueprints/blob/main/CAST-1/CAST-1-WizMote.yaml
+  input:
+    cast1_device:
+      name: Apollo CAST-1
+      description: Select your CAST-1 from the dropdown!
+      selector:
+        device:
+          filter:
+            - integration: esphome
+              manufacturer: ApolloAutomation
+              model: CAST-1-W
+            - integration: esphome
+              manufacturer: ApolloAutomation
+              model: CAST-1-ETH
+          multiple: false
+    button_on:
+      name: "On button"
+      icon: mdi:gesture-tap-button
+      collapsed: true
+      input:
+        on_mode:
+          name: Action
+          description: "Default: Play"
+          default: "Play"
+          selector:
+            select:
+              mode: dropdown
+              options: &actions
+                - "Nothing"
+                - "Play"
+                - "Pause"
+                - "Play / Pause"
+                - "Next Track"
+                - "Previous Track"
+                - "Volume Up"
+                - "Volume Down"
+                - "Toggle Light"
+                - "Send HA Event"
+        on_action:
+          name: Custom action
+          description: Run when Action is set to "Send HA Event".
+          default: []
+          selector:
+            action:
+    button_off:
+      name: "Off button"
+      icon: mdi:gesture-tap-button
+      collapsed: true
+      input:
+        off_mode:
+          name: Action
+          description: "Default: Pause"
+          default: "Pause"
+          selector:
+            select:
+              mode: dropdown
+              options: *actions
+        off_action:
+          name: Custom action
+          description: Run when Action is set to "Send HA Event".
+          default: []
+          selector:
+            action:
+    button_night:
+      name: "Night button"
+      icon: mdi:gesture-tap-button
+      collapsed: true
+      input:
+        night_mode:
+          name: Action
+          description: "Default: Toggle Light"
+          default: "Toggle Light"
+          selector:
+            select:
+              mode: dropdown
+              options: *actions
+        night_action:
+          name: Custom action
+          description: Run when Action is set to "Send HA Event".
+          default: []
+          selector:
+            action:
+    button_bright_up:
+      name: "Brightness Up button"
+      icon: mdi:gesture-tap-button
+      collapsed: true
+      input:
+        bright_up_mode:
+          name: Action
+          description: "Default: Volume Up"
+          default: "Volume Up"
+          selector:
+            select:
+              mode: dropdown
+              options: *actions
+        bright_up_action:
+          name: Custom action
+          description: Run when Action is set to "Send HA Event".
+          default: []
+          selector:
+            action:
+    button_bright_down:
+      name: "Brightness Down button"
+      icon: mdi:gesture-tap-button
+      collapsed: true
+      input:
+        bright_down_mode:
+          name: Action
+          description: "Default: Volume Down"
+          default: "Volume Down"
+          selector:
+            select:
+              mode: dropdown
+              options: *actions
+        bright_down_action:
+          name: Custom action
+          description: Run when Action is set to "Send HA Event".
+          default: []
+          selector:
+            action:
+    button_1:
+      name: "Button 1"
+      icon: mdi:gesture-tap-button
+      collapsed: true
+      input:
+        button_1_mode:
+          name: Action
+          description: "Default: Previous Track"
+          default: "Previous Track"
+          selector:
+            select:
+              mode: dropdown
+              options: *actions
+        button_1_action:
+          name: Custom action
+          description: Run when Action is set to "Send HA Event".
+          default: []
+          selector:
+            action:
+    button_2:
+      name: "Button 2"
+      icon: mdi:gesture-tap-button
+      collapsed: true
+      input:
+        button_2_mode:
+          name: Action
+          description: "Default: Next Track"
+          default: "Next Track"
+          selector:
+            select:
+              mode: dropdown
+              options: *actions
+        button_2_action:
+          name: Custom action
+          description: Run when Action is set to "Send HA Event".
+          default: []
+          selector:
+            action:
+    button_3:
+      name: "Button 3"
+      icon: mdi:gesture-tap-button
+      collapsed: true
+      input:
+        button_3_mode:
+          name: Action
+          description: "Default: Send HA Event"
+          default: "Send HA Event"
+          selector:
+            select:
+              mode: dropdown
+              options: *actions
+        button_3_action:
+          name: Custom action
+          description: Run when Action is set to "Send HA Event".
+          default: []
+          selector:
+            action:
+    button_4:
+      name: "Button 4"
+      icon: mdi:gesture-tap-button
+      collapsed: true
+      input:
+        button_4_mode:
+          name: Action
+          description: "Default: Send HA Event"
+          default: "Send HA Event"
+          selector:
+            select:
+              mode: dropdown
+              options: *actions
+        button_4_action:
+          name: Custom action
+          description: Run when Action is set to "Send HA Event".
+          default: []
+          selector:
+            action:
+
+mode: queued
+max: 10
+
+variables:
+  cast1_device: !input cast1_device
+
+# Two jobs:
+#  - on HA start / save (id: sync) push each button's chosen Action down to the
+#    matching WizMote select on the device, so the device page mirrors this UI.
+#  - on a button event (the device only emits one when its Action is "Send HA
+#    Event") run that button's custom action.
+triggers:
+  - trigger: homeassistant
+    event: start
+    id: sync
+  - trigger: event
+    event_type: automation_reloaded
+    id: sync
+  - trigger: event
+    event_type: esphome.cast1_wizmote_event
+    event_data: { button: "on" }
+    id: "on"
+  - trigger: event
+    event_type: esphome.cast1_wizmote_event
+    event_data: { button: "off" }
+    id: "off"
+  - trigger: event
+    event_type: esphome.cast1_wizmote_event
+    event_data: { button: "night" }
+    id: "night"
+  - trigger: event
+    event_type: esphome.cast1_wizmote_event
+    event_data: { button: "brightness_up" }
+    id: "brightness_up"
+  - trigger: event
+    event_type: esphome.cast1_wizmote_event
+    event_data: { button: "brightness_down" }
+    id: "brightness_down"
+  - trigger: event
+    event_type: esphome.cast1_wizmote_event
+    event_data: { button: "1" }
+    id: "button_1"
+  - trigger: event
+    event_type: esphome.cast1_wizmote_event
+    event_data: { button: "2" }
+    id: "button_2"
+  - trigger: event
+    event_type: esphome.cast1_wizmote_event
+    event_data: { button: "3" }
+    id: "button_3"
+  - trigger: event
+    event_type: esphome.cast1_wizmote_event
+    event_data: { button: "4" }
+    id: "button_4"
+
+actions:
+  - choose:
+      - conditions:
+          - condition: trigger
+            id: sync
+        sequence:
+          - repeat:
+              for_each:
+                - { suffix: "wizmote_on", option: !input on_mode }
+                - { suffix: "wizmote_off", option: !input off_mode }
+                - { suffix: "wizmote_night", option: !input night_mode }
+                - { suffix: "wizmote_brightness_up", option: !input bright_up_mode }
+                - { suffix: "wizmote_brightness_down", option: !input bright_down_mode }
+                - { suffix: "wizmote_button_1", option: !input button_1_mode }
+                - { suffix: "wizmote_button_2", option: !input button_2_mode }
+                - { suffix: "wizmote_button_3", option: !input button_3_mode }
+                - { suffix: "wizmote_button_4", option: !input button_4_mode }
+              sequence:
+                - action: select.select_option
+                  continue_on_error: true
+                  target:
+                    entity_id: >-
+                      {{ device_entities(cast1_device)
+                         | select('search', '_' ~ repeat.item.suffix ~ '$')
+                         | list | first }}
+                  data:
+                    option: "{{ repeat.item.option }}"
+      - conditions:
+          - condition: trigger
+            id: "on"
+        sequence: !input on_action
+      - conditions:
+          - condition: trigger
+            id: "off"
+        sequence: !input off_action
+      - conditions:
+          - condition: trigger
+            id: "night"
+        sequence: !input night_action
+      - conditions:
+          - condition: trigger
+            id: "brightness_up"
+        sequence: !input bright_up_action
+      - conditions:
+          - condition: trigger
+            id: "brightness_down"
+        sequence: !input bright_down_action
+      - conditions:
+          - condition: trigger
+            id: "button_1"
+        sequence: !input button_1_action
+      - conditions:
+          - condition: trigger
+            id: "button_2"
+        sequence: !input button_2_action
+      - conditions:
+          - condition: trigger
+            id: "button_3"
+        sequence: !input button_3_action
+      - conditions:
+          - condition: trigger
+            id: "button_4"
+        sequence: !input button_4_action

--- a/CAST-1/README.md
+++ b/CAST-1/README.md
@@ -1,0 +1,66 @@
+# Apollo CAST-1 WizMote
+
+[![Import Blueprint](https://my.home-assistant.io/badges/blueprint_import.svg)](https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fgithub.com%2FApolloAutomation%2FBlueprints%2Fblob%2Fmain%2FCAST-1%2FCAST-1-WizMote.yaml)
+
+Make your WizMote control the **Apollo Automation CAST-1** exactly how you want. Assign any of the nine WizMote buttons to media playback controls, a light toggle, or a custom Home Assistant action.
+
+---
+
+## Features
+
+- 🎵 Every button ships with a sensible default (Play, Pause, Volume, Next, Previous) — override any of them by picking another option from its dropdown
+- 🏠 Set a button to **Send HA Event** to run a custom action instead — play a Music Assistant playlist, toggle a room's lights, run a scene or script, anything HA can do
+- 🔄 Your picks are written down to the CAST-1's per-button selects on HA start and on save, so the device page always mirrors this automation — no need to open the device page
+
+### Per-button Actions
+
+Each button offers the same dropdown:
+
+```
+Nothing · Play · Pause · Play / Pause · Next Track · Previous Track ·
+Volume Up · Volume Down · Toggle Light · Send HA Event
+```
+
+| Button | Default |
+|---|---|
+| On | Play |
+| Off | Pause |
+| Night | Toggle Light |
+| Brightness Up | Volume Up |
+| Brightness Down | Volume Down |
+| Button 1 | Previous Track |
+| Button 2 | Next Track |
+| Button 3 | Send HA Event |
+| Button 4 | Send HA Event |
+
+---
+
+## Requirements
+
+- **Apollo Automation CAST-1** (`CAST-1-W` or `CAST-1-ETH`) connected to Home Assistant via ESPHome, paired with a WizMote
+- CAST-1 firmware with WizMote Home Assistant control (the per-button selects + `cast1_wizmote_event`)
+
+---
+
+## Setup
+
+1. Click the **Import Blueprint** badge above, or copy the URL and paste it into
+   **Settings → Automations & Scenes → Blueprints → Import Blueprint**
+
+2. Create a new automation from the blueprint
+
+3. **Select your CAST-1 device** from the dropdown
+
+4. Expand each button you want to change and pick an **Action** from its dropdown
+
+5. For any button set to **Send HA Event**, expand it and fill in the **Custom action** (TTS, lights, scenes, scripts…)
+
+---
+
+## Resources
+
+- [CAST-1 Product Page](https://apolloautomation.com)
+- [CAST-1 Wiki & Documentation](https://wiki.apolloautomation.com)
+- [Apollo Automation Discord](http://dsc.gg/ApolloAutomation)
+- [GitHub — CAST-1 Firmware](https://github.com/ApolloAutomation/CAST-1)
+- [Apollo Automation Blueprints](https://github.com/ApolloAutomation/Blueprints)


### PR DESCRIPTION
Home Assistant automation blueprint for the Apollo CAST-1 WizMote, moved out of the CAST-1 firmware repo (was in ApolloAutomation/CAST-1#35) so it lives alongside the other Apollo blueprints.

Each of the nine WizMote buttons gets an Action dropdown (Nothing / Play / Pause / Play / Pause / Next / Previous / Volume Up / Volume Down / Toggle Light / Send HA Event) plus a custom action. On HA start and on save the blueprint writes the picks down to the device's per-button selects, so the device page always mirrors the automation. Buttons set to Send HA Event run the custom action. Routing uses native event triggers + event_data filters + trigger IDs; the device picker is filtered to CAST-1-W / CAST-1-ETH.

Pairs with the firmware in ApolloAutomation/CAST-1#35.

Adds:
- CAST-1/CAST-1-WizMote.yaml
- CAST-1/README.md (import badge + setup, matching the other product folders)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced Home Assistant automation blueprint for ESPHome WizMote CAST-1 devices with per-button action configuration
  * Supports customizable actions for On, Off, Night Mode, Brightness Up/Down, and 4 additional buttons
  * Enables custom Home Assistant event routing

* **Documentation**
  * Added setup and configuration guide for the WizMote automation blueprint

<!-- end of auto-generated comment: release notes by coderabbit.ai -->