### PR TITLE
Fix PLT-1 temperature thresholds pinned to °C

### DIFF
--- a/PLT-1/PLT-1.yaml
+++ b/PLT-1/PLT-1.yaml
@@ -295,25 +295,29 @@ blueprint:
             boolean:
 
         min_soil_temp:
-          name: Minimum Soil Temperature (°C)
-          description: Alert when soil temperature drops below this value — roots may be too cold.
+          name: Minimum Soil Temperature
+          description: >
+            Alert when soil temperature drops below this value — roots may be
+            too cold. Use the unit your sensor shows in Home Assistant.
+            10 °C / 50 °F is a good starting point.
           default: 10
           selector:
             number:
-              min: -10
-              max: 50
-              unit_of_measurement: "°C"
+              min: -20
+              max: 130
               step: 0.5
 
         max_soil_temp:
-          name: Maximum Soil Temperature (°C)
-          description: Alert when soil temperature rises above this value — roots may overheat.
+          name: Maximum Soil Temperature
+          description: >
+            Alert when soil temperature rises above this value — roots may
+            overheat. Use the unit your sensor shows in Home Assistant.
+            30 °C / 86 °F is a good starting point.
           default: 30
           selector:
             number:
-              min: -10
-              max: 50
-              unit_of_measurement: "°C"
+              min: -20
+              max: 130
               step: 0.5
 
     # ── Air Temperature (collapsed) ────────────────────────────────────────────────
@@ -329,25 +333,29 @@ blueprint:
             boolean:
 
         min_air_temp:
-          name: Minimum Air Temperature (°C)
-          description: Alert when ambient temperature drops below this value.
+          name: Minimum Air Temperature
+          description: >
+            Alert when ambient temperature drops below this value. Use the
+            unit your sensor shows in Home Assistant. 15 °C / 59 °F is a good
+            starting point.
           default: 15
           selector:
             number:
-              min: -10
-              max: 50
-              unit_of_measurement: "°C"
+              min: -20
+              max: 130
               step: 0.5
 
         max_air_temp:
-          name: Maximum Air Temperature (°C)
-          description: Alert when ambient temperature rises above this value.
+          name: Maximum Air Temperature
+          description: >
+            Alert when ambient temperature rises above this value. Use the
+            unit your sensor shows in Home Assistant. 32 °C / 90 °F is a good
+            starting point.
           default: 32
           selector:
             number:
-              min: -10
-              max: 50
-              unit_of_measurement: "°C"
+              min: -20
+              max: 130
               step: 0.5
 
     # ── Air Humidity (collapsed) ───────────────────────────────────────────────────


### PR DESCRIPTION
The four soil/air temperature inputs are labeled °C with a -10..50 range. HA converts temperature sensor states to the user's unit system, so on a °F install the state is Fahrenheit but the threshold is Celsius: "below 10" is -12 °C (cold alerts never fire) and "above 30" matches normal room readings (heat alerts fire on every repeat check once enabled).

This drops the °C pin the same way AIR-1's min/max temperature inputs handle it:

- Names lose the "(°C)" suffix, selectors lose `unit_of_measurement`
- Range widened to -20..130 so both scales fit
- Each description says to use the unit the sensor shows in HA, with dual-unit starting points (e.g. 10 °C / 50 °F)

Defaults are unchanged. Existing automations keep their stored values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated soil and air temperature alert settings to use clearer, unit-aware labels and guidance.
  * Expanded allowed temperature ranges for both minimum and maximum values, supporting a wider set of sensor readings.
  * Removed fixed temperature units so the app can follow the sensor’s displayed unit automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->